### PR TITLE
고객 주문 생성 기능 구현

### DIFF
--- a/src/main/java/com/sparta/gitandrun/common/advice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/gitandrun/common/advice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.sparta.gitandrun.common.advice.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j(topic = "GlobalExceptionHandler")
+public class GlobalExceptionHandler {
+    @ExceptionHandler({IllegalArgumentException.class})
+    public ResponseEntity<RestApiException> illegalArgumentExceptionHandler(IllegalArgumentException ex) {
+        RestApiException restApiException = new RestApiException(ex.getMessage(), HttpStatus.BAD_REQUEST.value());
+        log.error(ex.getMessage());
+        return new ResponseEntity<>(
+                restApiException,
+                HttpStatus.BAD_REQUEST
+        );
+    }
+}

--- a/src/main/java/com/sparta/gitandrun/common/advice/exception/RestApiException.java
+++ b/src/main/java/com/sparta/gitandrun/common/advice/exception/RestApiException.java
@@ -1,0 +1,11 @@
+package com.sparta.gitandrun.common.advice.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RestApiException {
+    private String errorMessage;
+    private int statusCode;
+}

--- a/src/main/java/com/sparta/gitandrun/common/entity/ApiResDto.java
+++ b/src/main/java/com/sparta/gitandrun/common/entity/ApiResDto.java
@@ -1,0 +1,20 @@
+package com.sparta.gitandrun.common.entity;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResDto {
+    private String msg;
+    private Integer statusCode;
+
+    public ApiResDto(String msg, Integer statusCode) {
+        this.msg = msg;
+        this.statusCode = statusCode;
+    }
+}

--- a/src/main/java/com/sparta/gitandrun/common/entity/BaseEntity.java
+++ b/src/main/java/com/sparta/gitandrun/common/entity/BaseEntity.java
@@ -1,0 +1,38 @@
+package com.sparta.gitandrun.common.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime updatedAt;
+
+    @Column
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime deletedAt;
+
+    @Column(nullable = false)
+    private String createdBy;
+
+    @Column(nullable = false)
+    private String updatedBy;
+
+    private String deletedBy;
+
+}

--- a/src/main/java/com/sparta/gitandrun/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/gitandrun/menu/repository/MenuRepository.java
@@ -1,17 +1,17 @@
 package com.sparta.gitandrun.menu.repository;
 
 import com.sparta.gitandrun.menu.entity.Menu;
-import com.sparta.gitandrun.menu.service.MenuService;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.List;
+import java.util.Optional;
 
 
-@Repository
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    @Query("select m from Menu m where m.id = :menuId and m.isDeleted = false ")
+    Optional<Menu> findByIdAndIsDeletedFalse(@Param("menuId") Long menuId);
 
 
 //    List<Menu> findAllBy(Menu menu);

--- a/src/main/java/com/sparta/gitandrun/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/gitandrun/menu/repository/MenuRepository.java
@@ -5,13 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
+import java.util.List;
 
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
 
-    @Query("select m from Menu m where m.id = :menuId and m.isDeleted = false ")
-    Optional<Menu> findByIdAndIsDeletedFalse(@Param("menuId") Long menuId);
+    @Query("select m from Menu m where m.id in :menuIds and m.isDeleted = false")
+    List<Menu> findByIdsAndIsDeletedFalse(@Param("menuIds") List<Long> menuIds);
 
 
 //    List<Menu> findAllBy(Menu menu);

--- a/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
@@ -1,0 +1,33 @@
+package com.sparta.gitandrun.order.controller;
+
+import com.sparta.gitandrun.common.entity.ApiResDto;
+import com.sparta.gitandrun.order.dto.req.CreateOrderReqDto;
+import com.sparta.gitandrun.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/order")
+@RestController
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    /*
+        주문생성 메서드
+        1. @Secured("CUSTOMER") 추후 접근 권한 처리
+        2. 매개변수로 User 추가할 것
+    */
+    @PostMapping
+    public ResponseEntity<ApiResDto> createOrder(@RequestBody CreateOrderReqDto dto) {
+
+        orderService.createOrder(dto);
+
+        return ResponseEntity.ok().body(new ApiResDto("주문 완료", HttpStatus.OK.value()));
+    }
+}

--- a/src/main/java/com/sparta/gitandrun/order/dto/req/CreateOrderReqDto.java
+++ b/src/main/java/com/sparta/gitandrun/order/dto/req/CreateOrderReqDto.java
@@ -3,10 +3,11 @@ package com.sparta.gitandrun.order.dto.req;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 public class CreateOrderReqDto {
-    private Long menuId;
-    private int count;
+    private List<Long> menuIds;
     private boolean isType;
 }

--- a/src/main/java/com/sparta/gitandrun/order/dto/req/CreateOrderReqDto.java
+++ b/src/main/java/com/sparta/gitandrun/order/dto/req/CreateOrderReqDto.java
@@ -1,0 +1,12 @@
+package com.sparta.gitandrun.order.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateOrderReqDto {
+    private Long menuId;
+    private int count;
+    private boolean isType;
+}

--- a/src/main/java/com/sparta/gitandrun/order/entity/Order.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/Order.java
@@ -1,8 +1,8 @@
 package com.sparta.gitandrun.order.entity;
 
-import com.sparta.gitandrun.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,7 +15,7 @@ import static jakarta.persistence.CascadeType.PERSIST;
 @Getter
 @Table(name = "p_order")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order extends BaseEntity {
+public class Order {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,4 +29,28 @@ public class Order extends BaseEntity {
 
     @OneToMany(mappedBy = "order", cascade = PERSIST, orphanRemoval = true)
     private List<OrderMenu> orderMenus = new ArrayList<>();
+
+    @Builder
+    public Order (OrderType type) {
+        this.orderType = type;
+    }
+
+    // == 연관관계 메서드 == //
+    public void addOrderMenu(OrderMenu orderMenu) {
+        orderMenus.add(orderMenu);
+        orderMenu.updateOrder(this);
+    }
+
+    // == 생성 메서드 == //
+    public static Order createOrder(boolean type, OrderMenu... orderMenus) {
+        Order order = Order.builder()
+                .type(type ? OrderType.DELIVERY : OrderType.VISIT)
+                .build();
+
+        for (OrderMenu orderMenu : orderMenus) {
+            order.addOrderMenu(orderMenu);
+        }
+
+        return order;
+    }
 }

--- a/src/main/java/com/sparta/gitandrun/order/entity/Order.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/Order.java
@@ -35,21 +35,18 @@ public class Order {
         this.orderType = type;
     }
 
-    // == 연관관계 메서드 == //
-    public void addOrderMenu(OrderMenu orderMenu) {
-        orderMenus.add(orderMenu);
-        orderMenu.updateOrder(this);
+    public void addOrderMenus(List<OrderMenu> orderMenus) {
+        this.orderMenus.addAll(orderMenus);
+        orderMenus.forEach(orderMenu -> orderMenu.updateOrder(this));
     }
 
     // == 생성 메서드 == //
-    public static Order createOrder(boolean type, OrderMenu... orderMenus) {
+    public static Order createOrder(boolean type, List<OrderMenu> orderMenus) {
         Order order = Order.builder()
                 .type(type ? OrderType.DELIVERY : OrderType.VISIT)
                 .build();
 
-        for (OrderMenu orderMenu : orderMenus) {
-            order.addOrderMenu(orderMenu);
-        }
+        order.addOrderMenus(orderMenus);
 
         return order;
     }

--- a/src/main/java/com/sparta/gitandrun/order/entity/Order.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/Order.java
@@ -1,0 +1,23 @@
+package com.sparta.gitandrun.order.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private OrderType orderType;
+
+    private boolean isDeleted;
+}

--- a/src/main/java/com/sparta/gitandrun/order/entity/Order.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/Order.java
@@ -1,15 +1,21 @@
 package com.sparta.gitandrun.order.entity;
 
+import com.sparta.gitandrun.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.CascadeType.PERSIST;
+
 @Entity
 @Getter
-@Table(name = "orders")
+@Table(name = "p_order")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order {
+public class Order extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,4 +26,7 @@ public class Order {
     private OrderType orderType;
 
     private boolean isDeleted;
+
+    @OneToMany(mappedBy = "order", cascade = PERSIST, orphanRemoval = true)
+    private List<OrderMenu> orderMenus = new ArrayList<>();
 }

--- a/src/main/java/com/sparta/gitandrun/order/entity/OrderMenu.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/OrderMenu.java
@@ -1,0 +1,33 @@
+package com.sparta.gitandrun.order.entity;
+
+import com.sparta.gitandrun.menu.entity.Menu;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@Table(name = "p_order_menu")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderMenu {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private int orderPrice;
+
+    @Column(nullable = false)
+    private int orderCount;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "p_order_id")
+    private Order order;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "p_menu_id")
+    private Menu menu;
+}

--- a/src/main/java/com/sparta/gitandrun/order/entity/OrderMenu.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/OrderMenu.java
@@ -3,6 +3,7 @@ package com.sparta.gitandrun.order.entity;
 import com.sparta.gitandrun.menu.entity.Menu;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,4 +31,25 @@ public class OrderMenu {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "p_menu_id")
     private Menu menu;
+
+    @Builder
+    public OrderMenu(Menu menu, int orderCount, int orderPrice) {
+        this.menu = menu;
+        this.orderCount = orderCount;
+        this.orderPrice = orderPrice;
+    }
+
+    // == 연관관계 메서드 == //
+    public void updateOrder(Order order) {
+        this.order = order;
+    }
+
+    // == 생성 메서드 == //
+    public static OrderMenu createOrderMenu(Menu findMenu, int price, int count) {
+        return OrderMenu.builder()
+                .menu(findMenu)
+                .orderCount(count)
+                .orderPrice(price)
+                .build();
+    }
 }

--- a/src/main/java/com/sparta/gitandrun/order/entity/OrderMenu.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/OrderMenu.java
@@ -7,6 +7,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+import java.util.Map;
+
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
@@ -45,11 +48,20 @@ public class OrderMenu {
     }
 
     // == 생성 메서드 == //
-    public static OrderMenu createOrderMenu(Menu findMenu, int price, int count) {
-        return OrderMenu.builder()
-                .menu(findMenu)
-                .orderCount(count)
-                .orderPrice(price)
-                .build();
+    public static List<OrderMenu> createOrderMenus(List<Menu> menus, Map<Menu, Long> menuCountMap) {
+
+        return menus.stream()
+                .map(
+                        menu -> {
+                            int count = menuCountMap.get(menu).intValue();
+
+                            return OrderMenu.builder()
+                                    .menu(menu)
+                                    .orderCount(count)
+                                    .orderPrice(menu.getPrice() * count)
+                                    .build();
+                        }
+                )
+                .toList();
     }
 }

--- a/src/main/java/com/sparta/gitandrun/order/entity/OrderType.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/OrderType.java
@@ -1,0 +1,21 @@
+package com.sparta.gitandrun.order.entity;
+
+public enum OrderType {
+    DELIVERY(Type.DELIVERY),
+    VISIT(Type.VISIT);
+
+    private final String type;
+
+    OrderType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public static class Type {
+        public static final String DELIVERY = "DELIVERY";
+        public static final String VISIT = "VISIT";
+    }
+}

--- a/src/main/java/com/sparta/gitandrun/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/gitandrun/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.gitandrun.order.repository;
+
+import com.sparta.gitandrun.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
+++ b/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
@@ -10,6 +10,10 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class OrderService {
@@ -21,30 +25,57 @@ public class OrderService {
     public void createOrder(CreateOrderReqDto dto) {
 
         /*
-        유저 조회
-        User findUser = userRepository.findUser(user.getId);
+            유저 조회
+            User findUser = userRepository.findUser(user.getId);
         */
 
         /*
-        메뉴 조회
+            메뉴 조회 및 중복된 메뉴 개수 계산
         */
-        Menu findMenu = menuRepository.findByIdAndIsDeletedFalse(dto.getMenuId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));
+        List<Menu> findMenus = getMenus(dto);
+
+        Map<Menu, Long> menuCountMap = getMenuCountMap(dto, findMenus);
 
         /*
-         주문 상품 생성
+            주문 상품 생성
         */
-        OrderMenu orderMenu = OrderMenu.createOrderMenu(findMenu, findMenu.getPrice(), dto.getCount());
+        List<OrderMenu> orderMenus = OrderMenu.createOrderMenus(findMenus, menuCountMap);
 
         /*
-        주문 생성
+            주문 생성
         */
-        Order order = Order.createOrder(dto.isType(), orderMenu);
+        Order order = Order.createOrder(dto.isType(), orderMenus);
 
         /*
-        주문 저장
+            주문 저장
         */
         orderRepository.save(order);
+    }
+
+
+    private List<Menu> getMenus(CreateOrderReqDto dto) {
+        List<Menu> findMenus = menuRepository.findByIdsAndIsDeletedFalse(dto.getMenuIds());
+
+        if (findMenus.isEmpty()) {
+            throw new NullPointerException("메뉴 목록이 비어있습니다.");
+        }
+        return findMenus;
+    }
+
+    private static Map<Menu, Long> getMenuCountMap(CreateOrderReqDto dto, List<Menu> findMenus) {
+        /*
+            1. 클라이언트로부터 전달 받은 menuId 의 리스트를 { 메뉴 Id : 개수 } 형태로 구성된 Map 으로 생성한다.
+            2. 이때 Collectors.counting() 키 값의 개수를 세는 역할을 한다.
+            3. 이후 { 메뉴 : 메뉴의 개수 } 형태로 구성된 Map 을 생성하여 반환한다.
+        */
+        Map<Long, Long> idsCountingMap = dto.getMenuIds().stream()
+                .collect(Collectors.groupingBy(menuId -> menuId, Collectors.counting()));
+
+        return findMenus.stream()
+                .collect(Collectors.toMap(
+                        menu -> menu,
+                        menu -> idsCountingMap.get(menu.getId())
+                ));
     }
 
 }

--- a/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
+++ b/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
@@ -1,0 +1,50 @@
+package com.sparta.gitandrun.order.service;
+
+import com.sparta.gitandrun.menu.entity.Menu;
+import com.sparta.gitandrun.menu.repository.MenuRepository;
+import com.sparta.gitandrun.order.dto.req.CreateOrderReqDto;
+import com.sparta.gitandrun.order.entity.Order;
+import com.sparta.gitandrun.order.entity.OrderMenu;
+import com.sparta.gitandrun.order.repository.OrderRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final MenuRepository menuRepository;
+
+    @Transactional
+    public void createOrder(CreateOrderReqDto dto) {
+
+        /*
+        유저 조회
+        User findUser = userRepository.findUser(user.getId);
+        */
+
+        /*
+        메뉴 조회
+        */
+        Menu findMenu = menuRepository.findByIdAndIsDeletedFalse(dto.getMenuId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));
+
+        /*
+         주문 상품 생성
+        */
+        OrderMenu orderMenu = OrderMenu.createOrderMenu(findMenu, findMenu.getPrice(), dto.getCount());
+
+        /*
+        주문 생성
+        */
+        Order order = Order.createOrder(dto.isType(), orderMenu);
+
+        /*
+        주문 저장
+        */
+        orderRepository.save(order);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,12 @@
-# PostgreSQL ?????? ??
+# PostgreSQL
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-# Hibernate ?? (JPA ?? ?)
+# Hibernate
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #2 

## 📝 Description

`Order` 와 `Menu` 엔티티 간의 관계를 `N:M` 기반으로 주문 기능을 구현하였습니다.
이때 `N:M` 관계를 해소하기 위해서 `OrderMenu` 중간 엔티티를 생성하였습니다.


한 번의 주문으로 여러 상품을 주문할 수 있도록 구현하였습니다.

```java
@Getter
@NoArgsConstructor
public class CreateOrderReqDto {
    private List<Long> menuIds;
    private boolean isType;
}
```

&rarr;  주문할 Menu 의 Id 를 List 형식으로 입력 받습니다.

```java
@Query("select m from Menu m where m.id in :menuIds and m.isDeleted = false")
List<Menu> findByIdsAndIsDeletedFalse(@Param("menuIds") List<Long> menuIds);


...

private List<Menu> getMenus(CreateOrderReqDto dto) {
        List<Menu> findMenus = menuRepository.findByIdsAndIsDeletedFalse(dto.getMenuIds());

        if (findMenus.isEmpty()) {
            throw new NullPointerException("메뉴 목록이 비어있습니다.");
        }
        return findMenus;
    }
```

→ `in 절`을 사용하여 메뉴 `ID`가 포함된 리스트를 매개변수로 받아 해당하는 메뉴를 조회하고, 이를 `List<Menu>` 형태로 반환합니다.
→ 이때 `isDeleted = false` 조건을 추가하여, 논리삭제 되지 않은 menu 만 조회합니다.

```java
private static Map<Menu, Long> getMenuCountMap(CreateOrderReqDto dto, List<Menu> findMenus) {
  
        Map<Long, Long> idsCountingMap = dto.getMenuIds().stream()
                .collect(Collectors.groupingBy(menuId -> menuId, Collectors.counting()));

        return findMenus.stream()
                .collect(Collectors.toMap(
                        menu -> menu,
                        menu -> idsCountingMap.get(menu.getId())
                ));
    }
```

→ `Collectors.groupingBy` 와 `Collectors.counting()` 을 사용하여 `{ 메뉴 ID : 개수 }` 형태의 `Map<Long, Long>` 을 생성합니다. 
→ 앞서 조회한 `findMenus` 를 순회하여, `idsCountingMap` 에서 각 메뉴의 id를 이용해 해당 메뉴의 개수를 가져옵니다.
→ 이러한 작업을 통해 최종적으로` Map<Menu, Long>` 를 반환하며, 이는 `각 메뉴와 해당 메뉴의 개수 정보` 를 나타냅니다.

```java
List<OrderMenu> orderMenus = OrderMenu.createOrderMenus(findMenus, menuCountMap);

...


    public static List<OrderMenu> createOrderMenus(List<Menu> menus, Map<Menu, Long> menuCountMap) {

        return menus.stream()
                .map(
                        menu -> {
                            int count = menuCountMap.get(menu).intValue();

                            return OrderMenu.builder()
                                    .menu(menu)
                                    .orderCount(count)
                                    .orderPrice(menu.getPrice() * count)
                                    .build();
                        }
                )
                .toList();
    }

```
→ 메뉴 리스트와 메뉴별 개수를 기반으로 `OrderMenu` 객체를 생성합니다.

```java
Order order = Order.createOrder(dto.isType(), orderMenus);

...

public static Order createOrder(boolean type, List<OrderMenu> orderMenus) {
        Order order = Order.builder()
                .type(type ? OrderType.DELIVERY : OrderType.VISIT)
                .build();

        order.addOrderMenus(orderMenus);

        return order;
    }

...

public void addOrderMenus(List<OrderMenu> orderMenus) {
        this.orderMenus.addAll(orderMenus);
        orderMenus.forEach(orderMenu -> orderMenu.updateOrder(this));
    }
```
→ 최종적으로 주문 객체를 생성합니다.
→ 클라이런트로부터 받은 `boolean` 값을 이용해 삼항연산자를 통하여 `주문 타입을 동적` 으로 결정합니다.
→ `addOrderMenus` 에서는 `OrderMenu` 객체들을 `Order` 객체의 `orderMenus` 리스트에 추가하고, 각 `OrderMenu` 객체에 `Order` 객체를 연결하여 양방향 연관 관계를 설정합니다.

**PostMan**
<img width="974" alt="스크린샷 2024-11-08 오전 2 33 13" src="https://github.com/user-attachments/assets/d1c2209d-3385-46a7-89a3-9487da162f12">

**Order**
![스크린샷 2024-11-08 오전 2 33 55](https://github.com/user-attachments/assets/8d6dbdfc-f136-4855-80fe-0ee7f4385fb0)

**OrderMenu**
![스크린샷 2024-11-08 오전 2 34 57](https://github.com/user-attachments/assets/48fb95f1-8cbe-4a5b-a221-5d67e0ae658f)


## 💬 To Reivewers

- 메뉴 리스트를 조회하고 이를 { 메뉴 : 개수 } 로 매핑하는 과정이 복잡하다고 느낍니다. 이를 좀 더 간소화 할 수 있는 방향이 없을지 의견 주세요 !
- 주문 타입을 `boolean` 으로 받아, 해당 값에 따라 주문 타입의 Enum 클래스가 정해집니다. 다른 방법으로 주문 타입을 결정할 수 있는 방법이 있을까요 ?
- API 응답의 통일성을 위해 `ApiResDto` 를 생성하여 적용시켰습니다. 확인부탁드립니다.
- `GlobalExceptionHandler` 를 생성하였습니다. `IllegalArgumentException` 은 모두 여기서 관리될 것입니다. 해당 Global 설정은 추후 확장 계획입니다.
- Hibernate 로그 출력 설정 추가하였습니다. 이제 쿼리를 좀 더 명시적으로 확인하실 수 있을 겁니다.