### PR TITLE
주문의 상태를 나타낼 수 있는 ENUM 추가

### DIFF
--- a/src/main/java/com/sparta/gitandrun/order/entity/Order.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/Order.java
@@ -23,6 +23,10 @@ public class Order {
 
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
+    private OrderStatus orderStatus;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
     private OrderType orderType;
 
     private boolean isDeleted;
@@ -31,7 +35,8 @@ public class Order {
     private List<OrderMenu> orderMenus = new ArrayList<>();
 
     @Builder
-    public Order (OrderType type) {
+    public Order (OrderStatus status, OrderType type) {
+        this.orderStatus = status;
         this.orderType = type;
     }
 
@@ -43,6 +48,7 @@ public class Order {
     // == 생성 메서드 == //
     public static Order createOrder(boolean type, List<OrderMenu> orderMenus) {
         Order order = Order.builder()
+                .status(OrderStatus.PENDING)
                 .type(type ? OrderType.DELIVERY : OrderType.VISIT)
                 .build();
 

--- a/src/main/java/com/sparta/gitandrun/order/entity/OrderStatus.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/OrderStatus.java
@@ -1,0 +1,20 @@
+package com.sparta.gitandrun.order.entity;
+
+public enum OrderStatus {
+
+    PENDING(Status.PENDING),
+    CANCEL(Status.CANCEL),
+    COMPLETED(Status.COMPLETED);
+
+    public final String status;
+
+    OrderStatus (String status) {
+        this.status = status;
+    }
+
+    public static class Status {
+        public static final String PENDING = "ORDER_PENDING";
+        public static final String CANCEL = "ORDER_CANCEL";
+        public static final String COMPLETED = "ORDER_COMPLETED";
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #2 

## 📝 Description

- 요구사항에 따라 주문의 상태값을 나타낼 수 있는 Enum 클래스를 생성하였습니다.

- `PENDING`, `CANCEL`, `COMPLETED` 로 이루어져 있습니다.

- 최초  주문이 생성될 경우에는 `PENDING` 으로 결정됩니다.

- 이후 결제까지 완료되면 `COMPLETED` 로 결정되며, 이때 리뷰를 작성할 수 있습니다.

- 결제간 문제가 발생하여 취소할 경우 주문의 상태는 `CANCEL` 이 될 것입니다.

## 💬 To Reivewers