### PR TITLE
고객 주문 취소 기능 구현

### DIFF
--- a/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
@@ -6,10 +6,7 @@ import com.sparta.gitandrun.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/order")
 @RestController
@@ -29,5 +26,18 @@ public class OrderController {
         orderService.createOrder(dto);
 
         return ResponseEntity.ok().body(new ApiResDto("주문 완료", HttpStatus.OK.value()));
+    }
+
+    /*
+       주문취소 메서드
+       1. @Secured("CUSTOMER, ADMIN") 추후 접근 권한 처리
+       2. 매개변수로 User 추가할 것
+   */
+    @PatchMapping("/{orderId}/cancel")
+    public ResponseEntity<ApiResDto> cancelOrder(@PathVariable("orderId") Long orderId) {
+
+        orderService.cancelOrder(orderId);
+
+        return ResponseEntity.ok().body(new ApiResDto("주문 취소 완료", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/com/sparta/gitandrun/order/entity/Order.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/Order.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static jakarta.persistence.CascadeType.PERSIST;
 
@@ -55,5 +56,13 @@ public class Order {
         order.addOrderMenus(orderMenus);
 
         return order;
+    }
+
+    // == 주문 취소 메서드 == //
+    public void cancelOrder() {
+        if (Objects.equals(this.getOrderStatus().status, OrderStatus.CANCEL.status)) {
+            throw new IllegalArgumentException("이미 취소가 된 주문입니다.");
+        }
+        this.orderStatus = OrderStatus.CANCEL;
     }
 }

--- a/src/main/java/com/sparta/gitandrun/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/gitandrun/order/repository/OrderRepository.java
@@ -2,6 +2,12 @@ package com.sparta.gitandrun.order.repository;
 
 import com.sparta.gitandrun.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
+    @Query("select o from Order o where o.id = :orderId and o.isDeleted = false ")
+    Optional<Order> findOrderById(@Param("orderId") Long orderId);
 }

--- a/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
+++ b/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
@@ -1,14 +1,15 @@
 package com.sparta.gitandrun.order.service;
 
+
 import com.sparta.gitandrun.menu.entity.Menu;
 import com.sparta.gitandrun.menu.repository.MenuRepository;
 import com.sparta.gitandrun.order.dto.req.CreateOrderReqDto;
 import com.sparta.gitandrun.order.entity.Order;
 import com.sparta.gitandrun.order.entity.OrderMenu;
 import com.sparta.gitandrun.order.repository.OrderRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final MenuRepository menuRepository;
 
+    // 주문 생성
     @Transactional
     public void createOrder(CreateOrderReqDto dto) {
 
@@ -52,6 +54,24 @@ public class OrderService {
         orderRepository.save(order);
     }
 
+    // 주문 취소
+    @Transactional
+    public void cancelOrder(Long orderId) {
+        /*
+            본인 검증 메서드 추후 구현 예정
+        */
+//        private void checkOrderAccessPermission (User user, Order findOrder){
+//            if (!user.getId().equals(findOrder.getUser().getId())) {
+//                Objects.equals();
+//                throw new IllegalArgumentException("해당 주문에 대한 접근 권한이 없습니다.");
+//            }
+//        }
+//
+        Order findOrder = orderRepository.findOrderById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));
+
+        findOrder.cancelOrder();
+    }
 
     private List<Menu> getMenus(CreateOrderReqDto dto) {
         List<Menu> findMenus = menuRepository.findByIdsAndIsDeletedFalse(dto.getMenuIds());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #2 

## 📝 Description

- `@PatchMapping`을 통해 주문 취소 요청을 처리하도록 설정

- 주문 ID를 통해 주문 조회 후 상태를 `CANCEL`로 변경

- 주문이 이미 취소된 경우 예외 발생 처리

- 추후 접근 권한 검증 메서드 구현 예정

**최초 주문 상태**
![스크린샷 2024-11-08 오후 5 37 49](https://github.com/user-attachments/assets/49578d38-e792-4ccf-b41e-3adcfe487fa9)

**Postman 요청**
<img width="979" alt="스크린샷 2024-11-08 오후 5 38 41" src="https://github.com/user-attachments/assets/b7822d09-975c-49fc-aaed-0d7e79923d2b">

**취소된 주문 상태**
![스크린샷 2024-11-08 오후 5 39 17](https://github.com/user-attachments/assets/f890a293-d002-4c25-aa8f-31eabfccdc9d)

**이미 취소된 주문 예외**
<img width="514" alt="스크린샷 2024-11-08 오후 5 39 56" src="https://github.com/user-attachments/assets/2d5dec6e-7321-4eec-a5f6-3b63de22a4bc">

## 💬 To Reivewers

검토 부탁드리겠습니다.