### PR TITLE
주문 거절 기능 구현

### DIFF
--- a/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
@@ -40,4 +40,17 @@ public class OrderController {
 
         return ResponseEntity.ok().body(new ApiResDto("주문 취소 완료", HttpStatus.OK.value()));
     }
+
+    /*
+       주문거절 메서드
+       1. @Secured("OWNER, MANAGER") 추후 접근 권한 처리
+       2. 매개변수로 User 추가할 것
+   */
+    @PatchMapping("/{orderId}/reject")
+    private ResponseEntity<ApiResDto> rejectOrder(@PathVariable("orderId") Long orderId) {
+
+        orderService.rejectOrder(orderId);
+
+        return ResponseEntity.ok().body(new ApiResDto("주문 거절 완료", HttpStatus.OK.value()));
+    }
 }

--- a/src/main/java/com/sparta/gitandrun/order/entity/Order.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/Order.java
@@ -36,7 +36,7 @@ public class Order {
     private List<OrderMenu> orderMenus = new ArrayList<>();
 
     @Builder
-    public Order (OrderStatus status, OrderType type) {
+    public Order(OrderStatus status, OrderType type) {
         this.orderStatus = status;
         this.orderType = type;
     }
@@ -64,5 +64,13 @@ public class Order {
             throw new IllegalArgumentException("이미 취소가 된 주문입니다.");
         }
         this.orderStatus = OrderStatus.CANCEL;
+    }
+
+    // == 주문 거절 메서드 == //
+    public void rejectOrder() {
+        if (!Objects.equals(this.getOrderStatus().status, OrderStatus.PENDING.status)) {
+            throw new IllegalArgumentException("해당 주문은 이미 취소, 완료 또는 거절된 상태입니다.");
+        }
+        this.orderStatus = OrderStatus.REJECT;
     }
 }

--- a/src/main/java/com/sparta/gitandrun/order/entity/OrderStatus.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/OrderStatus.java
@@ -4,7 +4,8 @@ public enum OrderStatus {
 
     PENDING(Status.PENDING),
     CANCEL(Status.CANCEL),
-    COMPLETED(Status.COMPLETED);
+    COMPLETED(Status.COMPLETED),
+    REJECT(Status.REJECT);
 
     public final String status;
 
@@ -16,5 +17,6 @@ public enum OrderStatus {
         public static final String PENDING = "ORDER_PENDING";
         public static final String CANCEL = "ORDER_CANCEL";
         public static final String COMPLETED = "ORDER_COMPLETED";
+        public static final String REJECT = "ORDER_REJECT";
     }
 }

--- a/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
+++ b/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
@@ -67,10 +67,27 @@ public class OrderService {
 //            }
 //        }
 //
-        Order findOrder = orderRepository.findOrderById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));
+        Order findOrder = getOrder(orderId);
 
         findOrder.cancelOrder();
+    }
+
+    // 주문 거절
+    @Transactional
+    public void rejectOrder(Long orderId) {
+
+        Order findOrder = getOrder(orderId);
+
+        /*
+            본인 가게 주문 검증 메서드 구현 필요
+        */
+
+        findOrder.rejectOrder();
+    }
+
+    private Order getOrder(Long orderId) {
+        return orderRepository.findOrderById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));
     }
 
     private List<Menu> getMenus(CreateOrderReqDto dto) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #15 

## 📝 Description

- `@PatchMapping`을 통해 주문 거절 요청을 처리하도록 설정

- 주문 ID를 통해 주문 조회 후 상태를 `REJECT`로 변경

- 주문이 이미 취소, 완료, 거절 상태면 예외 발생

- 추후 접근 권한 검증 메서드 구현 예정

## 💬 To Reivewers

검토 부탁드립니다.