### PR TITLE
Feature/28/store search sort

### DIFF
--- a/src/main/java/com/sparta/gitandrun/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/gitandrun/menu/entity/Menu.java
@@ -59,11 +59,9 @@ public class Menu extends BaseEntity {
     @Column(nullable = true, length = 100)
     private String deletedBy;
 
-/*  Store Entity 생성시 ManyToOne관계로 조인하여 연결
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
-*/
 
 //    @PrePersist
 //    public void PrePersist() {

--- a/src/main/java/com/sparta/gitandrun/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/gitandrun/store/controller/StoreController.java
@@ -4,6 +4,7 @@ import com.sparta.gitandrun.common.entity.ApiResDto;
 import com.sparta.gitandrun.store.dto.FullStoreResponse;
 import com.sparta.gitandrun.store.dto.LimitedStoreResponse;
 import com.sparta.gitandrun.store.dto.StoreRequestDto;
+import com.sparta.gitandrun.store.dto.StoreSearchRequestDto;
 import com.sparta.gitandrun.store.entity.Store;
 import com.sparta.gitandrun.store.repository.StoreRepository;
 import com.sparta.gitandrun.store.service.StoreService;
@@ -12,6 +13,10 @@ import com.sparta.gitandrun.user.entity.User;
 import com.sparta.gitandrun.user.repository.UserRepository;
 import com.sparta.gitandrun.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +40,7 @@ public class StoreController {
         this.storeRepository = storeRepository;
     }
 
+    // 가게 등록
     @PostMapping
     @Transactional
     public Store createStore(UUID userId, @RequestBody StoreRequestDto storeRequestDto) {
@@ -66,8 +72,7 @@ public class StoreController {
         return storeRepository.save(newStore);
     }
 
-
-
+    // ID로 조회
     @GetMapping("/{storeId}")
     public ResponseEntity<?> getStoreDetails(
             @PathVariable UUID storeId,
@@ -76,12 +81,14 @@ public class StoreController {
         return storeService.getStoreDetails(storeId, userId);
     }
 
+    // 전체 가게 조회
     @GetMapping
     public ResponseEntity<?> getAllStores(@RequestParam UUID userId) {
         List<?> stores = storeService.getAllStores(userId);
         return ResponseEntity.ok(stores);
     }
 
+    // 가게 수정
     @PatchMapping("/{storeId}")
     public ResponseEntity<?> updateStore(@PathVariable UUID storeId,
                                          @RequestParam UUID userId,
@@ -95,6 +102,7 @@ public class StoreController {
         }
     }
 
+    // 삭제 기능
     @DeleteMapping("/{storeId}")
     public ResponseEntity<ApiResDto> deleteStore(
             @PathVariable UUID storeId,
@@ -107,5 +115,32 @@ public class StoreController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(new ApiResDto("삭제 권한이 없습니다.", 403));
         }
+    }
+
+    // 카테고리로 검색
+    @GetMapping("/search")
+    public ResponseEntity<Page<?>> searchStores(
+            @RequestParam(required = false) UUID categoryId,
+            @RequestParam(defaultValue = "createdAt") String sortField,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam String role) {
+
+        Page<?> stores = storeService.searchStores(categoryId, sortField, page, size, role);
+        return ResponseEntity.ok(stores);
+    }
+
+    // 키워드로 검색
+    @GetMapping("/search/keyword")
+    public ResponseEntity<Page<?>> searchStoresByKeyword(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "createdAt") String sortField,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false, defaultValue = "asc") String sortDirection,
+            @RequestParam String role) {
+
+        Page<?> stores = storeService.searchStoresByKeyword(keyword, sortField, page, size, role); // Page<Store>로 리턴
+        return ResponseEntity.ok(stores);
     }
 }

--- a/src/main/java/com/sparta/gitandrun/store/dto/PagedResponse.java
+++ b/src/main/java/com/sparta/gitandrun/store/dto/PagedResponse.java
@@ -1,0 +1,19 @@
+package com.sparta.gitandrun.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PagedResponse<T> {
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+}

--- a/src/main/java/com/sparta/gitandrun/store/dto/StoreSearchRequestDto.java
+++ b/src/main/java/com/sparta/gitandrun/store/dto/StoreSearchRequestDto.java
@@ -1,0 +1,15 @@
+package com.sparta.gitandrun.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class StoreSearchRequestDto {
+    private String keyword; // 검색어
+    private String sort;    // 정렬 기준 ("createdAt" 또는 "updatedAt")
+    private int pageSize;   // 페이지당 건수 (10, 30, 50만 허용)
+    private int page;       // 페이지 번호 (0부터 시작)
+}

--- a/src/main/java/com/sparta/gitandrun/store/entity/Store.java
+++ b/src/main/java/com/sparta/gitandrun/store/entity/Store.java
@@ -53,7 +53,7 @@ public class Store {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    @Column(name = "is_deleted", nullable = false)
+    @Column(name = "is_deleted")
     private boolean isDeleted = false;
 
     @Column(name = "address", nullable = false, length = 255)
@@ -69,6 +69,7 @@ public class Store {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)  // Store 테이블에 user_id 컬럼 추가
     private User user;
+    
 
     @PrePersist
     public void prePersist() {

--- a/src/main/java/com/sparta/gitandrun/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/gitandrun/store/repository/StoreRepository.java
@@ -2,7 +2,11 @@ package com.sparta.gitandrun.store.repository;
 
 import com.sparta.gitandrun.store.entity.Store;
 import com.sparta.gitandrun.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +16,16 @@ public interface StoreRepository extends JpaRepository<Store, UUID> {
     List<Store> findByisDeletedFalse();
     Optional<Store> findById(UUID storeId); // Store의 ID로 조회하는 메서드
     List<Store> findByUser_UserId(UUID userId);  // userId로 Store 조회
+
+    @Query("SELECT s FROM Store s WHERE s.storeName LIKE %:keyword% OR s.address LIKE %:keyword% ORDER BY " +
+            "CASE WHEN :sort = 'createdAt' THEN s.createdAt END DESC, " +
+            "CASE WHEN :sort = 'updatedAt' THEN s.updatedAt END DESC")
+    Page<Store> searchStores(@Param("keyword") String keyword,
+                             @Param("sort") String sort,
+                             Pageable pageable);
+
+    Page<Store> findByCategoryId(UUID categoryId, Pageable pageable);
+
+    @Query("SELECT s FROM Store s WHERE s.storeName LIKE %:keyword% OR s.address LIKE %:keyword%")
+    Page<Store> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #28 
 
## 📝 Description
SpringDATAJPA를 통한 Search 메서드를 구현한 후 페이징 및 검색 기능을 만들었습니다.
<img width="772" alt="image" src="https://github.com/user-attachments/assets/913a10c7-b3fb-4689-b438-873ad8de26c2">
발제 프로젝트 예시에 있는대로 size와 sortField의 기준을 정하고 Pageable 객체를 통해 해당 값의 세팅에 따라 다른 값들이 나오게 만들었습니다.

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/a7007266-0190-468d-b88c-b11a941a4ed7">
현재 `22222222-2222-2222-2222-222222222222`의 categoryId를 Params에 넣어 요청을 보낼 경우 customer는 위처럼 제한된 정보만을 가지게 됩니다.

<img width="857" alt="image" src="https://github.com/user-attachments/assets/5111f49c-6e05-45de-b654-fa5ba53f03fd">

반면, 권한이 있는 유저가 위와 같은 요청을 보낼 경우에는 모든 정보를 가질 수 있습니다.

<img width="813" alt="image" src="https://github.com/user-attachments/assets/334d37bc-e2ad-4b3f-af38-e22c9d74976a">

Pageable 객체 관련이나 페이징 관련 정보들은 두 요청 모두 해당 세팅에 대한 값을 반환합니다. 프론트의 경우에는 이러한 정보를 통해 페이징 UI를 구현할 수 있을 것 입니다.


## 💬 To Reivewers
<img width="677" alt="image" src="https://github.com/user-attachments/assets/969086f8-f540-4c55-ab7b-23cb8847d925">

현재는 기본 Default 값을 Controller 계층에서 Param에 대한 defaultValue를 설정해서 진행했습니다. 현재 이게 가독성이 좀 더 좋아보여서 이와 같은 선택을 했지만 '이런 로직 자체는 Service 계층에서 처리하는 것이 옳은 것 같다'와 같은 의견이 있으시면 다른 분들과 통일하겠습니다!

또한 다른 도메인과 매핑이 되기 전까지는 기존의 코드를 고도화할 예정입니다!
매핑 후에는 가게를 조회하면 리뷰가 나오게 구현할 예정입니다.