### PR TITLE
Search 메서드 파라미터 : Role -> userId

### DIFF
--- a/src/main/java/com/sparta/gitandrun/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/gitandrun/store/controller/StoreController.java
@@ -125,9 +125,9 @@ public class StoreController {
             @RequestParam(defaultValue = "createdAt") String sortField,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam String role) {
+            @RequestParam Long userId) {
 
-        Page<?> stores = storeService.searchStores(categoryId, sortField, page, size, role);
+        Page<?> stores = storeService.searchStores(categoryId, sortField, page, size, userId);
         return ResponseEntity.ok(stores);
     }
 
@@ -139,9 +139,9 @@ public class StoreController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false, defaultValue = "asc") String sortDirection,
-            @RequestParam String role) {
+            @RequestParam Long userId) {
 
-        Page<?> stores = storeService.searchStoresByKeyword(keyword, sortField, page, size, role); // Page<Store>로 리턴
+        Page<?> stores = storeService.searchStoresByKeyword(keyword, sortField, page, size, userId); // Page<Store>로 리턴
         return ResponseEntity.ok(stores);
     }
 }

--- a/src/main/java/com/sparta/gitandrun/store/service/StoreService.java
+++ b/src/main/java/com/sparta/gitandrun/store/service/StoreService.java
@@ -163,36 +163,29 @@ public class StoreService {
     }
 
     // 페이징 및 조건부 정렬 구현
-    public Page<?> searchStores(UUID categoryId, String sortField, int page, int size, String role) {
-//        // sortField가 없으면 기본값 "createdAt" 사용함
-//        sortField = (sortField == null || sortField.isBlank()) ? "createdAt" : sortField;
-//        Sort sort = Sort.by(sortField).ascending();
-//
-//        // size는 10, 30, 50 중 하나로 제한하고, 기본값으로 10 사용
-//        size = (size == 10 || size == 30 || size == 50) ? size : 10;
+    public Page<?> searchStores(UUID categoryId, String sortField, int page, int size, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(sortField).descending());
         Page<Store> stores = storeRepository.findByCategoryId(categoryId, pageable);
 
-        if ("ADMIN".equalsIgnoreCase(role)) {
+        if (user.getRole() == Role.ADMIN) {
             return stores.map(FullStoreResponse::new); // 관리자: 모든 정보 표시
         } else {
             return stores.map(LimitedStoreResponse::new); // 소유자 및 고객: 제한된 정보만 표시
         }
-
-
     }
 
     // 키워드 검색 및 권한에 따른 응답 제어
-    public Page<?> searchStoresByKeyword(String keyword, String sortField, int page, int size, String role) {
-//        // 기본값 설정
-//        sortField = (sortField == null || sortField.isBlank()) ? "createdAt" : sortField;
-//        Sort sort = Sort.by(sortField).descending();
+    public Page<?> searchStoresByKeyword(String keyword, String sortField, int page, int size, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(sortField).descending());
         Page<Store> stores = storeRepository.searchByKeyword(keyword, pageable);
 
-        if ("ADMIN".equalsIgnoreCase(role)) {
+        if (user.getRole() == Role.ADMIN) {
             return stores.map(FullStoreResponse::new); // 관리자: 모든 정보 표시
         } else {
             return stores.map(LimitedStoreResponse::new); // 소유자 및 고객: 제한된 정보만 표시


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #36 

## 📝 Description
![image](https://github.com/user-attachments/assets/8f5a82cc-bd3f-4b04-9146-59645c37dce8)
기존의 코드는 Role=ADMIN 이런식으로 param을 입력해주면 이에 맞게 if문에서 처리합니다.
이럴 경우 URL에 직접적으로 Role을 입력하기 때문에 잘못된 설계라고 생각합니다.
이번에 User 도메인과 연결하면서 이에 관련된 로직을 userId를 가져와 그 유저의 권한에 따라 적절한 응답을 반환하게 고쳤습니다.

<img width="1013" alt="image" src="https://github.com/user-attachments/assets/34dd591f-6686-41c7-ad2d-573c3e8ed03c">
먼저 카테고리의 파라미터를 Role에서 userId로 바꿨기 때문에 다음처럼 잘 실행됩니다.

<img width="992" alt="image" src="https://github.com/user-attachments/assets/42d20ec3-183b-4070-9e5c-d3f4d7aff16e">
또한 키워드로 검색을 할때에도 userId를 입력해주면 권한에 따라 응답을 제한할 수 있습니다.

## 💬 To Reivewers
현재 구현하지 않은 부분은 유저 로그인 기능 구현입니다. 
로그인 기능 구현 시 로그인된 유저의 정보를 가져와서 처리할 수 있게 다시 코드 수정하겠습니다.