### PR TITLE
카테고리 도메인 독립

### DIFF
--- a/src/main/java/com/sparta/gitandrun/category/controller/CategoryController.java
+++ b/src/main/java/com/sparta/gitandrun/category/controller/CategoryController.java
@@ -1,0 +1,69 @@
+package com.sparta.gitandrun.category.controller;
+
+import com.sparta.gitandrun.common.entity.ApiResDto;
+import com.sparta.gitandrun.category.dto.CategoryRequestDto;
+import com.sparta.gitandrun.category.entity.Category;
+import com.sparta.gitandrun.category.service.CategoryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    // 모든 카테고리 조회
+    @GetMapping
+    public ResponseEntity<ApiResDto> getAllCategories() {
+        List<Category> categories = categoryService.getAllCategories();
+        ApiResDto response = new ApiResDto("카테고리 조회 성공", 200, categories);
+        return ResponseEntity.ok(response);
+    }
+
+    // 새로운 카테고리 추가
+    @PostMapping
+    public ResponseEntity<ApiResDto> createCategory(@RequestBody CategoryRequestDto categoryRequest) {
+        try {
+            Category newCategory = categoryService.addCategory(categoryRequest.getName());
+            ApiResDto response = new ApiResDto("카테고리 추가 성공", 201, newCategory);
+            return ResponseEntity.status(201).body(response);
+        } catch (IllegalArgumentException e) {
+            ApiResDto errorResponse = new ApiResDto("카테고리 추가 실패: " + e.getMessage(), 400);
+            return ResponseEntity.badRequest().body(errorResponse);
+        }
+    }
+
+    // 카테고리 수정
+    @PatchMapping("/{categoryId}")
+    public ResponseEntity<ApiResDto> updateCategory(@PathVariable UUID categoryId, @RequestBody CategoryRequestDto categoryRequest) {
+        try {
+            Category updatedCategory = categoryService.updateCategory(categoryId, categoryRequest.getName());
+            ApiResDto response = new ApiResDto("카테고리 이름이 성공적으로 수정되었습니다.", 200, updatedCategory);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            ApiResDto errorResponse = new ApiResDto("카테고리 수정 실패: " + e.getMessage(), 400);
+            return ResponseEntity.badRequest().body(errorResponse);
+        }
+    }
+
+    // 카테고리 삭제 (옵션)
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<ApiResDto> deleteCategory(@PathVariable UUID categoryId) {
+        try {
+            categoryService.deleteCategory(categoryId);
+            ApiResDto response = new ApiResDto("카테고리 삭제 성공", 200);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            ApiResDto errorResponse = new ApiResDto("카테고리 삭제 실패: " + e.getMessage(), 400);
+            return ResponseEntity.badRequest().body(errorResponse);
+        }
+    }
+}

--- a/src/main/java/com/sparta/gitandrun/category/dto/CategoryRequestDto.java
+++ b/src/main/java/com/sparta/gitandrun/category/dto/CategoryRequestDto.java
@@ -1,0 +1,10 @@
+package com.sparta.gitandrun.category.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CategoryRequestDto {
+    private String name;
+}

--- a/src/main/java/com/sparta/gitandrun/category/entity/Category.java
+++ b/src/main/java/com/sparta/gitandrun/category/entity/Category.java
@@ -1,0 +1,26 @@
+package com.sparta.gitandrun.category.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "p_category")
+@Setter
+@NoArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private String name;
+
+    public Category(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/sparta/gitandrun/category/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/gitandrun/category/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.gitandrun.category.repository;
+
+import com.sparta.gitandrun.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/sparta/gitandrun/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/gitandrun/category/service/CategoryService.java
@@ -1,0 +1,83 @@
+package com.sparta.gitandrun.category.service;
+
+import com.sparta.gitandrun.category.entity.Category;
+import com.sparta.gitandrun.category.repository.CategoryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public CategoryService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+//    @PostConstruct
+//    @Transactional
+//    public void initializeCategories() {
+//        if (categoryRepository.count() == 0) {
+//            categoryRepository.saveAll(List.of(
+//                    new Category(UUID.fromString("11111111-1111-1111-1111-111111111111"), "KOREAN"),
+//                    new Category(UUID.fromString("22222222-2222-2222-2222-222222222222"), "CHINESE"),
+//                    new Category(UUID.fromString("33333333-3333-3333-3333-333333333333"), "SNACK"),
+//                    new Category(UUID.fromString("44444444-4444-4444-4444-444444444444"), "CHICKEN"),
+//                    new Category(UUID.fromString("55555555-5555-5555-5555-555555555555"), "PIZZA")
+//            ));
+//        }
+//    }
+
+    @PostConstruct
+    @Transactional
+    public void initializeCategories() {
+        if (categoryRepository.count() == 0) {
+            categoryRepository.saveAll(List.of(
+                    new Category("KOREAN"),
+                    new Category("CHINESE"),
+                    new Category("SNACK"),
+                    new Category("CHICKEN"),
+                    new Category("PIZZA")
+            ));
+        }
+    }
+
+    // 새로운 카테고리를 추가하는 메서드
+    @Transactional
+    public Category addCategory(String name) {
+        Category category = new Category(name);
+        return categoryRepository.save(category);
+    }
+
+    // 카테고리 조회 메서드
+    public Optional<Category> getCategoryById(UUID id) {
+        return categoryRepository.findById(id);
+    }
+
+    // 모든 카테고리를 조회하는 메서드
+    public List<Category> getAllCategories() {
+        return categoryRepository.findAll();
+    }
+
+    // 카테고리 이름 수정 메서드
+    @Transactional
+    public Category updateCategory(UUID id, String newName) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+        category.setName(newName);
+        return categoryRepository.save(category);
+    }
+
+    // 카테고리 삭제 메서드
+    @Transactional
+    public void deleteCategory(UUID id) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+        categoryRepository.delete(category);
+    }
+}

--- a/src/main/java/com/sparta/gitandrun/common/entity/ApiResDto.java
+++ b/src/main/java/com/sparta/gitandrun/common/entity/ApiResDto.java
@@ -12,9 +12,16 @@ import lombok.Setter;
 public class ApiResDto {
     private String msg;
     private Integer statusCode;
+    private Object data;  // 응답 데이터 필드 추가
 
     public ApiResDto(String msg, Integer statusCode) {
         this.msg = msg;
         this.statusCode = statusCode;
+    }
+
+    public ApiResDto(String msg, Integer statusCode, Object data) {
+        this.msg = msg;
+        this.statusCode = statusCode;
+        this.data = data;
     }
 }

--- a/src/main/java/com/sparta/gitandrun/store/entity/Store.java
+++ b/src/main/java/com/sparta/gitandrun/store/entity/Store.java
@@ -1,15 +1,17 @@
 package com.sparta.gitandrun.store.entity;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.sparta.gitandrun.category.entity.Category;
+import com.sparta.gitandrun.region.entity.Region;
 import com.sparta.gitandrun.user.entity.User;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Table(name = "p_store")
@@ -21,10 +23,15 @@ public class Store {
 
     @Id
     @Column(name = "store_id", columnDefinition = "UUID")
-    private UUID storeId;
+    private UUID storeId = UUID.randomUUID();
 
-    @Column(name = "category_id", nullable = false, columnDefinition = "UUID")
-    private UUID categoryId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)  // FK로 `category_id`를 연결
+    private Category category;  // `UUID` 대신 `Category` 타입으로 참조
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id", nullable = false) // FK 관계로 `region_id` 추가
+    private Region region;
 
     @Column(name = "store_name", nullable = false, length = 100, unique = true)
     private String storeName;
@@ -32,21 +39,17 @@ public class Store {
     @Column(name = "phone", nullable = false, length = 20)
     private String phone;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "category", nullable = false)
-    private Category category;
-
     @Column(name = "created_by", nullable = false, length = 100)
     private String createdBy;
 
     @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
+    private LocalDateTime createdAt = LocalDateTime.now();
 
     @Column(name = "updated_by", nullable = false, length = 100)
     private String updatedBy;
 
     @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
+    private LocalDateTime updatedAt = LocalDateTime.now();
 
     @Column(name = "deleted_by", length = 100)
     private String deletedBy;
@@ -68,25 +71,15 @@ public class Store {
 
     // User와의 ManyToOne 관계 설정
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)  // Store 테이블에 user_id 컬럼 추가
+    @JoinColumn(name = "user_id", nullable = false)
     @JsonBackReference  // 순환 참조 방지
     private User user;
 
-
     @PrePersist
     public void prePersist() {
-        if (this.storeId == null) {
-            this.storeId = UUID.randomUUID();
-        }
-        if (this.createdAt == null) {
-            this.createdAt = LocalDateTime.now();
-        }
-        if (this.updatedAt == null) {
-            this.updatedAt = LocalDateTime.now();
-        }
-        if (this.category != null) {
-            this.categoryId = this.category.getUuid();
-        }
+        this.storeId = this.storeId == null ? UUID.randomUUID() : this.storeId;
+        this.createdAt = this.createdAt == null ? LocalDateTime.now() : this.createdAt;
+        this.updatedAt = this.updatedAt == null ? LocalDateTime.now() : this.updatedAt;
     }
 
     @PreUpdate
@@ -98,12 +91,5 @@ public class Store {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
         this.deletedBy = deletedBy;
-    }
-
-    public void setCategory(Category category) {
-        this.category = category;
-        if (category != null) {
-            this.categoryId = category.getUuid();  // 카테고리의 UUID를 자동 설정
-        }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #38 

## 📝 Description
카테고리 도메인이 커지면서 추후 확장성을 고려해 따로 독립시켰습니다.
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/947d904f-119a-4040-a0d8-fd85026ec4a4">
카테고리 생성을 name과 같이 보내면 랜덤 uuid 타입의 id를 생성해 새로운 카테고리를 생성합니다.

<img width="1004" alt="image" src="https://github.com/user-attachments/assets/6303911c-1c3a-4dd7-bb3a-2fc359133ebe">
전체 카테고리를 조회하면 다음과 같이 id와 name이 조회됩니다.

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/6962e3d3-c706-4275-923e-9540dcad31b4">
카테고리를 수정하면 다음처럼 네임이 잘 변경됩니다. 변경할 사항은 name밖에 없으므로 name만 보내면 됩니다.

<img width="1010" alt="image" src="https://github.com/user-attachments/assets/11660ccc-91b2-4845-9925-056f3ebc966d">
삭제도 예쁘게 잘 되네요~


## 💬 To Reivewers
기본적인 CRUD만 만들었습니다!