### PR TITLE
요구사항 Ai 질답 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,18 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.15.0'  // Google 인증 라이브러리
+    implementation 'com.squareup.okhttp3:okhttp:4.9.3'  // REST 요청을 위한 클라이언트
+
+
+
+    implementation platform('com.google.cloud:libraries-bom:26.49.0')
+    implementation 'com.google.cloud:google-cloud-storage'
+    implementation 'com.google.cloud:google-cloud-apikeys:0.51.0'
+
+    implementation 'org.json:json:20230227'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,14 +33,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'com.google.auth:google-auth-library-oauth2-http:1.15.0'  // Google 인증 라이브러리
-    implementation 'com.squareup.okhttp3:okhttp:4.9.3'  // REST 요청을 위한 클라이언트
-
-
-
-    implementation platform('com.google.cloud:libraries-bom:26.49.0')
-    implementation 'com.google.cloud:google-cloud-storage'
-    implementation 'com.google.cloud:google-cloud-apikeys:0.51.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
 
     implementation 'org.json:json:20230227'
 

--- a/src/main/java/com/sparta/gitandrun/googleAi/controller/AiController.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/controller/AiController.java
@@ -1,0 +1,17 @@
+package com.sparta.gitandrun.googleAi.controller;
+
+import com.sparta.gitandrun.menu.service.MenuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/Ai")
+@RequiredArgsConstructor
+public class AiController {
+
+    private final static String SECRET_KEY = "AIzaSyBok8WRU8OgJUvFnUFvD5DTEdzuuHlVTCU";
+
+    private final MenuService menuService;
+
+}

--- a/src/main/java/com/sparta/gitandrun/googleAi/controller/AiController.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/controller/AiController.java
@@ -18,13 +18,8 @@ public class AiController {
 
     //Question CREATE
     @PostMapping
-    public String createQuestion(@RequestBody String text) {
-//        System.out.println(text);
-        try {
-            return aiService.createQuestion(text);
-        } catch (IOException e) {
-            return e.getMessage();
-        }
+    public String createQuestion(@RequestBody String text) { // json 받아오게
+        return aiService.createQuestion(text);
     }
 
 }

--- a/src/main/java/com/sparta/gitandrun/googleAi/controller/AiController.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/controller/AiController.java
@@ -1,17 +1,30 @@
 package com.sparta.gitandrun.googleAi.controller;
 
-import com.sparta.gitandrun.menu.service.MenuService;
+import com.sparta.gitandrun.googleAi.service.AiService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+
 @RestController
-@RequestMapping("/Ai")
+@RequestMapping("/ai")
 @RequiredArgsConstructor
 public class AiController {
 
-    private final static String SECRET_KEY = "AIzaSyBok8WRU8OgJUvFnUFvD5DTEdzuuHlVTCU";
+    private final AiService aiService;
 
-    private final MenuService menuService;
+    //Question CREATE
+    @PostMapping
+    public String createQuestion(@RequestBody String text) {
+//        System.out.println(text);
+        try {
+            return aiService.createQuestion(text);
+        } catch (IOException e) {
+            return e.getMessage();
+        }
+    }
 
 }

--- a/src/main/java/com/sparta/gitandrun/googleAi/controller/AiController.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/controller/AiController.java
@@ -5,7 +5,6 @@ import com.sparta.gitandrun.googleAi.service.AiService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.util.List;
 
 @RestController

--- a/src/main/java/com/sparta/gitandrun/googleAi/controller/AiController.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/controller/AiController.java
@@ -1,13 +1,12 @@
 package com.sparta.gitandrun.googleAi.controller;
 
+import com.sparta.gitandrun.googleAi.dto.AiDto;
 import com.sparta.gitandrun.googleAi.service.AiService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequestMapping("/ai")
@@ -20,6 +19,11 @@ public class AiController {
     @PostMapping
     public String createQuestion(@RequestBody String text) { // json 받아오게
         return aiService.createQuestion(text);
+    }
+
+    @GetMapping
+    public List<AiDto> ReadQuestions(){
+        return aiService.getAllQuestions();
     }
 
 }

--- a/src/main/java/com/sparta/gitandrun/googleAi/dto/AiDto.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/dto/AiDto.java
@@ -5,9 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/sparta/gitandrun/googleAi/dto/AiDto.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/dto/AiDto.java
@@ -1,0 +1,31 @@
+package com.sparta.gitandrun.googleAi.dto;
+
+import com.sparta.gitandrun.googleAi.entity.Ai;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AiDto {
+
+    private String question;
+    private String answer;
+
+    private List<AiDto> aiList = new ArrayList<>();
+
+    public AiDto(Ai ai) {
+        this.question = ai.getQuestion();
+        this.answer = ai.getAnswer();
+    }
+
+    public AiDto(String Question, String Answer) {
+        this.question = Question;
+        this.answer = Answer;
+    }
+
+}

--- a/src/main/java/com/sparta/gitandrun/googleAi/dto/AiDto.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/dto/AiDto.java
@@ -16,7 +16,7 @@ public class AiDto {
     private String question;
     private String answer;
 
-    private List<AiDto> aiList = new ArrayList<>();
+
 
     public AiDto(Ai ai) {
         this.question = ai.getQuestion();

--- a/src/main/java/com/sparta/gitandrun/googleAi/entity/Ai.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/entity/Ai.java
@@ -17,7 +17,7 @@ public class Ai {
     @Id
     @Column(name = "aiId", columnDefinition = "UUID")
     @GeneratedValue(strategy = GenerationType.AUTO)
-    private UUID menuId;
+    private UUID Id;
 
     private String question;
 

--- a/src/main/java/com/sparta/gitandrun/googleAi/entity/Ai.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/entity/Ai.java
@@ -1,0 +1,26 @@
+package com.sparta.gitandrun.googleAi.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "p_ai")
+@NoArgsConstructor
+public class Ai {
+
+    @Id
+    @Column(name = "aiId", columnDefinition = "UUID")
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID menuId;
+
+    private String question;
+
+    private String answer;
+
+}

--- a/src/main/java/com/sparta/gitandrun/googleAi/entity/Ai.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/entity/Ai.java
@@ -1,5 +1,6 @@
 package com.sparta.gitandrun.googleAi.entity;
 
+import com.sparta.gitandrun.googleAi.dto.AiDto;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,4 +24,8 @@ public class Ai {
 
     private String answer;
 
+    public Ai(AiDto aiDto){
+        this.question = aiDto.getQuestion();
+        this.answer = aiDto.getAnswer();
+    }
 }

--- a/src/main/java/com/sparta/gitandrun/googleAi/repository/AiRepository.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/repository/AiRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.gitandrun.googleAi.repository;
+
+import com.sparta.gitandrun.googleAi.entity.Ai;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AiRepository extends JpaRepository<Ai, Long> {
+}

--- a/src/main/java/com/sparta/gitandrun/googleAi/service/AiService.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/service/AiService.java
@@ -1,38 +1,25 @@
 package com.sparta.gitandrun.googleAi.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sparta.gitandrun.googleAi.dto.AiDto;
-import com.sparta.gitandrun.googleAi.repository.AiRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
+
 
 import java.io.IOException;
-import java.net.URI;
-import java.util.List;
+
 
 @Service
 @Slf4j
 public class AiService {
 
-
     @Value("${google-api-key}")
     private String SECRET_KEY;
 
-    String projectId = "gen-lang-client-0589077725";
-
     private final OkHttpClient httpClient = new OkHttpClient();
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     //CREATE
     public String createQuestion(String text) throws IOException {
 
@@ -52,7 +39,6 @@ public class AiService {
         contents.put(jsonObject1);
         jsonObject0.put("contents",contents);
 
-
         System.out.println(jsonObject0);
 
         RequestBody body = RequestBody.create(
@@ -64,14 +50,11 @@ public class AiService {
                 .post(body)
                 .build();
 
-
-        try (Response response = httpClient.newCall(request).execute()) {
-            if (!response.isSuccessful()) throw new IOException("Unexpected code " + response);
-            JsonNode jsonResponse = objectMapper.readTree(response.body().string());
-            return jsonResponse.path("response").path("text").asText();
-
-
-        }
+            Response response = httpClient.newCall(request).execute();
+//        try (Response response = httpClient.newCall(request).execute()) {
+//            if (!response.isSuccessful()) throw new IOException("Unexpected code " + response);
+            return response.body().string();
+//        }
 
     }
 }

--- a/src/main/java/com/sparta/gitandrun/googleAi/service/AiService.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/service/AiService.java
@@ -1,45 +1,48 @@
 package com.sparta.gitandrun.googleAi.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
+import com.sparta.gitandrun.googleAi.dto.AiDto;
+import com.sparta.gitandrun.googleAi.entity.Ai;
+import com.sparta.gitandrun.googleAi.repository.AiRepository;
+import lombok.RequiredArgsConstructor;
 import okhttp3.*;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-
 import java.io.IOException;
 
 
 @Service
-@Slf4j
+@RequiredArgsConstructor
 public class AiService {
 
     @Value("${google-api-key}")
     private String SECRET_KEY;
 
     private final OkHttpClient httpClient = new OkHttpClient();
+    private final AiRepository aiRepository;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
     //CREATE
-    public String createQuestion(String text) throws IOException {
+    public String createQuestion(String text) {
 
         String url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=" + SECRET_KEY;
 
-        JSONObject jsonObject0 = new JSONObject(); // contents
+        JSONObject jsonObject0 = new JSONObject(); // contents Field 생성
         JSONArray contents = new JSONArray();
 
-        JSONObject jsonObject1 = new JSONObject(); // parts
+        JSONObject jsonObject1 = new JSONObject(); // parts Field 생성
         JSONArray parts = new JSONArray();
 
-        JSONObject jsonObject2 = new JSONObject(); // text
+        JSONObject jsonObject2 = new JSONObject(); // text Field 생성
 
-        jsonObject2.put("text",text);
+        jsonObject2.put("text",text + " 답변을 최대한 간결하게 50자 이하로");
         parts.put(jsonObject2);
         jsonObject1.put("parts",parts);
         contents.put(jsonObject1);
         jsonObject0.put("contents",contents);
-
-        System.out.println(jsonObject0);
 
         RequestBody body = RequestBody.create(
                 jsonObject0.toString(), MediaType.parse("application/json"));
@@ -50,11 +53,27 @@ public class AiService {
                 .post(body)
                 .build();
 
+        JsonNode jsonNode; // Response 객체를 반환받을 Json 객체
+
+        try {
             Response response = httpClient.newCall(request).execute();
-//        try (Response response = httpClient.newCall(request).execute()) {
-//            if (!response.isSuccessful()) throw new IOException("Unexpected code " + response);
-            return response.body().string();
-//        }
+            jsonNode = objectMapper.readTree(response.body().string());
+             }
+        catch (IOException e) {
+            throw new RuntimeException("잘못된 Response 입니다.");
+        }
+
+        String answer = jsonNode.path("candidates")
+                .get(0) // candidate 객체
+                .path("content")
+                .path("parts")
+                .get(0) // parts 객체
+                .path("text")
+                .asText(); // "text" 필드를 문자열로 반환
+        AiDto aiDto = new AiDto(text, answer);
+        aiRepository.save(new Ai(aiDto));
+
+        return answer;
 
     }
 }

--- a/src/main/java/com/sparta/gitandrun/googleAi/service/AiService.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/service/AiService.java
@@ -1,0 +1,7 @@
+package com.sparta.gitandrun.googleAi.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AiService {
+}

--- a/src/main/java/com/sparta/gitandrun/googleAi/service/AiService.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/service/AiService.java
@@ -1,7 +1,77 @@
 package com.sparta.gitandrun.googleAi.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.gitandrun.googleAi.dto.AiDto;
+import com.sparta.gitandrun.googleAi.repository.AiRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
 
 @Service
+@Slf4j
 public class AiService {
+
+
+    @Value("${google-api-key}")
+    private String SECRET_KEY;
+
+    String projectId = "gen-lang-client-0589077725";
+
+    private final OkHttpClient httpClient = new OkHttpClient();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    //CREATE
+    public String createQuestion(String text) throws IOException {
+
+        String url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=" + SECRET_KEY;
+
+        JSONObject jsonObject0 = new JSONObject(); // contents
+        JSONArray contents = new JSONArray();
+
+        JSONObject jsonObject1 = new JSONObject(); // parts
+        JSONArray parts = new JSONArray();
+
+        JSONObject jsonObject2 = new JSONObject(); // text
+
+        jsonObject2.put("text",text);
+        parts.put(jsonObject2);
+        jsonObject1.put("parts",parts);
+        contents.put(jsonObject1);
+        jsonObject0.put("contents",contents);
+
+
+        System.out.println(jsonObject0);
+
+        RequestBody body = RequestBody.create(
+                jsonObject0.toString(), MediaType.parse("application/json"));
+
+        Request request = new Request.Builder()
+                .url(url)
+                .addHeader("Content-Type", "application/json; charset=UTF-8")
+                .post(body)
+                .build();
+
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) throw new IOException("Unexpected code " + response);
+            JsonNode jsonResponse = objectMapper.readTree(response.body().string());
+            return jsonResponse.path("response").path("text").asText();
+
+
+        }
+
+    }
 }

--- a/src/main/java/com/sparta/gitandrun/googleAi/service/AiService.java
+++ b/src/main/java/com/sparta/gitandrun/googleAi/service/AiService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.gitandrun.googleAi.dto.AiDto;
 import com.sparta.gitandrun.googleAi.entity.Ai;
 import com.sparta.gitandrun.googleAi.repository.AiRepository;
+import com.sparta.gitandrun.menu.dto.MenuResponseDto;
+import com.sparta.gitandrun.menu.entity.Menu;
 import lombok.RequiredArgsConstructor;
 import okhttp3.*;
 import org.json.JSONArray;
@@ -12,6 +14,8 @@ import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Service
@@ -74,6 +78,17 @@ public class AiService {
         aiRepository.save(new Ai(aiDto));
 
         return answer;
+
+    }
+
+    //Read ( 전체 조회 )
+    public List<AiDto> getAllQuestions() {
+        List<Ai> aiList = aiRepository.findAll();
+        List<AiDto> responseDtoList = new ArrayList<>();
+        for (Ai ai : aiList) {
+            responseDtoList.add(new AiDto(ai));
+        }
+        return responseDtoList;
 
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,5 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
+# Google AI Studio SECRET-KEY
+google-api-key=${GOOGLE_API_KEY:[Google_API_SECRET_KEY]}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #51 

## 📝 Description
Ai 도메인으로 Create 및 Read만 구현하였습니다. ( Update, Delete 미 구현 )
applicationproperties에 google-api-key의 경우 환경변수를 다른 properties로 저장하려 하였으나,
google-api-key는 따로 공유하여야 되는 부분은 같다고 생각 되어 작성하지 않았습니다.

- **AI API 연동**
    - **상품 설명 자동 생성:** AI API를 연동하여 가게 사장님이 상품 설명을 쉽게 작성할 수 있도록 지원
    - **AI 요청 기록:** AI API 요청 질문과 대답은 모두 데이터베이스에 저장

위의 요구사항에 따라, 
Post 방식으로는 AI API를 연동하여 질문을 Text 형식으로 받을 경우 Gemini AI API를 사용해 답변을 반환하도록 하였습니다
Get 방식으로는 모든 질답을 조회하도록 구현해 두었습니다.
![image](https://github.com/user-attachments/assets/fa1ba654-b017-4581-8779-0aa61437cb26)
![image](https://github.com/user-attachments/assets/efa2e88e-2477-43ca-b0a0-82799b5b47dc)



## 💬 To Reivewers

- 금~토요일 중으로 여유가 있으면 UserId를 역시 포함하여 Customer는 접근 불가, Owner는 본인의 질문만 조회, 생성 가능
- 나머지 Master와 Manager는 모든 질문 조회 및 생성 가능으로 하면 좋을 것 같은데 어떻게 생각하시나요?