### PR TITLE
사장 주문 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/gitandrun/common/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/gitandrun/common/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -29,6 +30,7 @@ import static org.springframework.security.access.hierarchicalroles.RoleHierarch
 @EnableWebSecurity
 @RequiredArgsConstructor
 @Slf4j
+@EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
 
    private final JwtUtil jwtUtil;
@@ -74,11 +76,6 @@ public class SecurityConfig {
                                "/user/signup",
                                "/user/login"
                        ).permitAll()
-                       .requestMatchers("/user/password").hasAnyRole("CUSTOMER","OWNER")
-                       .requestMatchers("/user/all").hasAnyRole("MANGER","ADMIN")
-                       .requestMatchers("/user/delete").hasRole("MANAGER")
-                       .requestMatchers("/admin/**").hasRole("MANAGER")
-                       .requestMatchers("/stores/**").hasAnyRole("OWNER", "MANAGER", "ADMIN")
                        .anyRequest().authenticated()
                )
                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
@@ -4,7 +4,7 @@ import com.sparta.gitandrun.common.entity.ApiResDto;
 import com.sparta.gitandrun.order.dto.req.CreateOrderReqDto;
 import com.sparta.gitandrun.order.dto.res.ResDto;
 import com.sparta.gitandrun.order.dto.res.ResOrderGetByIdDTO;
-import com.sparta.gitandrun.order.dto.res.ResOrderGetDTO;
+import com.sparta.gitandrun.order.dto.res.ResOrderGetByCustomerDTO;
 import com.sparta.gitandrun.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -13,8 +13,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RequestMapping("/order")
 @RestController
@@ -43,7 +41,7 @@ public class OrderController {
        3. @PathVariable 삭제하고 인증 객체를 받아 user 정보를 받은 예정
    */
     @GetMapping("/{userId}")
-    public ResponseEntity<ResDto<ResOrderGetDTO>> readOrder(
+    public ResponseEntity<ResDto<ResOrderGetByCustomerDTO>> readOrder(
             @PathVariable("userId")Long userId,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 

--- a/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
@@ -47,12 +47,13 @@ public class OrderController {
        2. 추후, 주문 상태별 / 최신순 및 오래된 순 등 다양한 기준에 따라 정렬 및 조회 가능한 동적 쿼리 작성 예정
        3. @PathVariable 삭제하고 인증 객체를 받아 user 정보를 받은 예정
    */
-    @GetMapping("/{userId}")
-    public ResponseEntity<ResDto<ResOrderGetByCustomerDTO>> readOrder(
-            @PathVariable("userId") Long userId,
+    @Secured("ROLE_CUSTOMER")
+    @GetMapping("/customer")
+    public ResponseEntity<ResDto<ResOrderGetByCustomerDTO>> getByCustomer(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return orderService.getBy(userId, pageable);
+        return orderService.getByCustomer(userDetails.getUser(), pageable);
     }
 
     /*
@@ -62,7 +63,7 @@ public class OrderController {
 
     @Secured("ROLE_OWNER")
     @GetMapping("/owner")
-    public ResponseEntity<ResDto<ResOrderGetByOwnerDTO>> readOrder(
+    public ResponseEntity<ResDto<ResOrderGetByOwnerDTO>> getByOwner(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 

--- a/src/main/java/com/sparta/gitandrun/order/dto/res/ResOrderGetByCustomerDTO.java
+++ b/src/main/java/com/sparta/gitandrun/order/dto/res/ResOrderGetByCustomerDTO.java
@@ -19,12 +19,12 @@ import java.util.stream.Collectors;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ResOrderGetDTO {
+public class ResOrderGetByCustomerDTO {
 
     private OrderPage orderPage;
 
-    public static ResOrderGetDTO of(Page<Order> orderPage, List<OrderMenu> orderMenus) {
-        return ResOrderGetDTO.builder()
+    public static ResOrderGetByCustomerDTO of(Page<Order> orderPage, List<OrderMenu> orderMenus) {
+        return ResOrderGetByCustomerDTO.builder()
                 .orderPage(new OrderPage(orderPage, orderMenus))
                 .build();
     }

--- a/src/main/java/com/sparta/gitandrun/order/dto/res/ResOrderGetByOwnerDTO.java
+++ b/src/main/java/com/sparta/gitandrun/order/dto/res/ResOrderGetByOwnerDTO.java
@@ -1,0 +1,142 @@
+package com.sparta.gitandrun.order.dto.res;
+
+import com.sparta.gitandrun.order.entity.Order;
+import com.sparta.gitandrun.order.entity.OrderMenu;
+import com.sparta.gitandrun.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.web.PagedModel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResOrderGetByOwnerDTO {
+
+    private OrderPage orderPage;
+
+    public static ResOrderGetByOwnerDTO of(Page<Order> orderPage, List<OrderMenu> orderMenus) {
+        return ResOrderGetByOwnerDTO.builder()
+                .orderPage(new ResOrderGetByOwnerDTO.OrderPage(orderPage, orderMenus))
+                .build();
+    }
+
+    @Getter
+    private static class OrderPage extends PagedModel<OrderPage.OrderDTO> {
+
+        public OrderPage(Page<Order> orderPage, List<OrderMenu> orderMenus) {
+            super(
+                    new PageImpl<>(
+                            OrderDTO.from(orderPage.getContent(), orderMenus),
+                            orderPage.getPageable(),
+                            orderPage.getTotalElements()
+                    )
+            );
+        }
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        private static class OrderDTO {
+            private Long orderId;
+            private String status;
+            private String type;
+            private Customer customer;
+            private List<OrderMenuDTO> orderMenuDTOS;
+            private int totalPrice;
+
+            public static List<OrderDTO> from(List<Order> orders, List<OrderMenu> orderMenus) {
+                return orders.stream()
+                        .map(order -> from(order, orderMenus))
+                        .toList();
+            }
+
+            public static OrderDTO from(Order order, List<OrderMenu> orderMenus) {
+
+                List<OrderDTO.OrderMenuDTO> orderMenuDTOS = OrderMenuDTO.from(orderMenus).get(order.getId());
+
+                return OrderDTO.builder()
+                        .orderId(order.getId())
+                        .status(order.getOrderStatus().status)
+                        .type(order.getOrderType().getType())
+                        .orderMenuDTOS(orderMenuDTOS)
+                        .customer(Customer.from(order.getUser()))
+                        .totalPrice(sumFrom(orderMenuDTOS))
+                        .build();
+            }
+
+            private static int sumFrom(List<OrderMenuDTO> orderMenuDTOS) {
+                return orderMenuDTOS.stream()
+                        .mapToInt(OrderMenuDTO::getMenuPrice)
+                        .sum();
+            }
+
+            @Getter
+            @Builder
+            @NoArgsConstructor
+            @AllArgsConstructor
+            private static class Customer {
+                private long userId;
+                private String nickName;
+                private String phone;
+                private String zipcode;
+                private String address;
+                private String addressDetail;
+
+                private static Customer from(User user) {
+                    return Customer.builder()
+                            .userId(user.getUserId())
+                            .nickName(user.getNickName())
+                            .phone(user.getPhone())
+                            .zipcode(user.getAddress().getZipCode())
+                            .zipcode(user.getAddress().getAddress())
+                            .zipcode(user.getAddress().getAddressDetail())
+                            .build();
+                }
+            }
+
+            @Getter
+            @Builder
+            @NoArgsConstructor
+            @AllArgsConstructor
+            private static class OrderMenuDTO {
+                private Long orderMenuId;
+                private UUID menuId;
+                private String menuName;
+                private int menuPrice;
+                private int count;
+
+                private static Map<Long, List<OrderMenuDTO>> from(List<OrderMenu> orderMenus) {
+                    return orderMenus.stream()
+                            .collect(Collectors.groupingBy(
+                                    orderMenu -> orderMenu.getOrder().getId(),
+                                    Collectors.mapping(
+                                            OrderMenuDTO::from,
+                                            Collectors.toList()
+                                    )
+                            ));
+                }
+
+                public static OrderMenuDTO from(OrderMenu orderMenu) {
+                    return OrderMenuDTO.builder()
+                            .orderMenuId(orderMenu.getId())
+                            .menuId(orderMenu.getMenu().getMenuId())
+                            .menuName(orderMenu.getMenu().getMenuName())
+                            .menuPrice(orderMenu.getOrderPrice())
+                            .count(orderMenu.getOrderCount())
+                            .build();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/sparta/gitandrun/order/repository/OrderMenuRepository.java
+++ b/src/main/java/com/sparta/gitandrun/order/repository/OrderMenuRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface OrderMenuRepository extends JpaRepository<OrderMenu, Long> {
     @Query("select om " +
@@ -19,4 +20,11 @@ public interface OrderMenuRepository extends JpaRepository<OrderMenu, Long> {
             "join fetch om.menu " +
             "where om.order.id = :orderId")
     List<OrderMenu> findByOrderId(@Param("orderId") Long orderId);
+
+    @Query("select om from OrderMenu om " +
+            "join fetch om.order " +
+            "join fetch om.menu m " +
+            "join fetch m.store s " +
+            "where s.storeId in :storeIds")
+    List<OrderMenu> findOrderMenusByStoreIdIn(@Param("storeIds") List<UUID> storeIds);
 }

--- a/src/main/java/com/sparta/gitandrun/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/gitandrun/order/repository/OrderRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
@@ -16,7 +17,14 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     //리뷰에서 orderId와 orderStatus 확인하기 위해 추가
     Optional<Order> findByIdAndOrderStatus(Long orderId, OrderStatus orderStatus);
-  
+
     Page<Order> findByUser_UserIdAndIsDeletedFalse(Long userId, Pageable pageable);
+
+    @Query("select o from Order o " +
+            "join fetch o.user " +
+            "where o.id in :orderIds " +
+            "and o.isDeleted = false ")
+    Page<Order> findByIdInAndIsDeletedFalse(@Param("orderIds") List<Long> orderIds, Pageable pageable);
+
 
 }

--- a/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
+++ b/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
@@ -6,7 +6,7 @@ import com.sparta.gitandrun.menu.repository.MenuRepository;
 import com.sparta.gitandrun.order.dto.req.CreateOrderReqDto;
 import com.sparta.gitandrun.order.dto.res.ResDto;
 import com.sparta.gitandrun.order.dto.res.ResOrderGetByIdDTO;
-import com.sparta.gitandrun.order.dto.res.ResOrderGetDTO;
+import com.sparta.gitandrun.order.dto.res.ResOrderGetByCustomerDTO;
 import com.sparta.gitandrun.order.entity.Order;
 import com.sparta.gitandrun.order.entity.OrderMenu;
 import com.sparta.gitandrun.order.repository.OrderMenuRepository;
@@ -73,7 +73,7 @@ public class OrderService {
     }
 
     @Transactional(readOnly = true)
-    public ResponseEntity<ResDto<ResOrderGetDTO>> getBy(Long userId, Pageable pageable) {
+    public ResponseEntity<ResDto<ResOrderGetByCustomerDTO>> getBy(Long userId, Pageable pageable) {
         /*
             주문 조회 : userId 를 기준으로
         */
@@ -85,10 +85,10 @@ public class OrderService {
         List<OrderMenu> orderMenus = getOrderMenusBy(getIdsBy(findOrderPage));
 
         return new ResponseEntity<>(
-                ResDto.<ResOrderGetDTO>builder()
+                ResDto.<ResOrderGetByCustomerDTO>builder()
                         .code(HttpStatus.OK.value())
                         .message("주문 조회에 성공했습니다.")
-                        .data(ResOrderGetDTO.of(findOrderPage, orderMenus))
+                        .data(ResOrderGetByCustomerDTO.of(findOrderPage, orderMenus))
                         .build(),
                 HttpStatus.OK
         );

--- a/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
+++ b/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
@@ -78,11 +78,11 @@ public class OrderService {
         Customer 본인 주문 내역 조회
     */
     @Transactional(readOnly = true)
-    public ResponseEntity<ResDto<ResOrderGetByCustomerDTO>> getBy(Long userId, Pageable pageable) {
+    public ResponseEntity<ResDto<ResOrderGetByCustomerDTO>> getByCustomer(User user, Pageable pageable) {
         /*
             주문 조회 : userId 를 기준으로
         */
-        Page<Order> findOrderPage = orderRepository.findByUser_UserIdAndIsDeletedFalse(userId, pageable);
+        Page<Order> findOrderPage = orderRepository.findByUser_UserIdAndIsDeletedFalse(user.getUserId(), pageable);
 
         /*
             주문 목록 조회 : 앞서 구한 order 의 id 를 기준으로

--- a/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
+++ b/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
@@ -5,13 +5,15 @@ import com.sparta.gitandrun.menu.entity.Menu;
 import com.sparta.gitandrun.menu.repository.MenuRepository;
 import com.sparta.gitandrun.order.dto.req.CreateOrderReqDto;
 import com.sparta.gitandrun.order.dto.res.ResDto;
-import com.sparta.gitandrun.order.dto.res.ResOrderGetByIdDTO;
 import com.sparta.gitandrun.order.dto.res.ResOrderGetByCustomerDTO;
+import com.sparta.gitandrun.order.dto.res.ResOrderGetByIdDTO;
+import com.sparta.gitandrun.order.dto.res.ResOrderGetByOwnerDTO;
 import com.sparta.gitandrun.order.entity.Order;
 import com.sparta.gitandrun.order.entity.OrderMenu;
 import com.sparta.gitandrun.order.repository.OrderMenuRepository;
 import com.sparta.gitandrun.order.repository.OrderRepository;
 import com.sparta.gitandrun.store.entity.Store;
+import com.sparta.gitandrun.store.repository.StoreRepository;
 import com.sparta.gitandrun.user.entity.User;
 import com.sparta.gitandrun.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class OrderService {
     private final OrderMenuRepository orderMenuRepository;
     private final MenuRepository menuRepository;
     private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
 
     // 주문 생성
     @Transactional
@@ -49,8 +52,7 @@ public class OrderService {
             메뉴 조회 및 중복된 메뉴 개수 계산
         */
 
-        User findUser = userRepository.findById(dto.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+        User findUser = getUserBy(dto.getUserId());
 
         List<Menu> findMenus = getMenus(dto);
 
@@ -72,6 +74,9 @@ public class OrderService {
         orderRepository.save(order);
     }
 
+    /*
+        Customer 본인 주문 내역 조회
+    */
     @Transactional(readOnly = true)
     public ResponseEntity<ResDto<ResOrderGetByCustomerDTO>> getBy(Long userId, Pageable pageable) {
         /*
@@ -89,6 +94,26 @@ public class OrderService {
                         .code(HttpStatus.OK.value())
                         .message("주문 조회에 성공했습니다.")
                         .data(ResOrderGetByCustomerDTO.of(findOrderPage, orderMenus))
+                        .build(),
+                HttpStatus.OK
+        );
+    }
+
+    /*
+        Owner 본인 가게 주문 조회
+    */
+    @Transactional(readOnly = true)
+    public ResponseEntity<ResDto<ResOrderGetByOwnerDTO>> getByOwner(User user, Pageable pageable) {
+
+        List<OrderMenu> findOrderMenus = getOrderMenus(user);
+
+        Page<Order> findOrderPage = orderRepository.findByIdInAndIsDeletedFalse(getIdsBy(findOrderMenus), pageable);
+
+        return new ResponseEntity<>(
+                ResDto.<ResOrderGetByOwnerDTO>builder()
+                        .code(HttpStatus.OK.value())
+                        .message("주문 조회에 성공했습니다.")
+                        .data(ResOrderGetByOwnerDTO.of(findOrderPage, findOrderMenus))
                         .build(),
                 HttpStatus.OK
         );
@@ -193,4 +218,28 @@ public class OrderService {
                 ));
     }
 
+
+    /*
+        본인 가게 주문 조회 메서드
+    */
+    private static List<Long> getIdsBy(List<OrderMenu> findOrderMenus) {
+        return findOrderMenus.stream()
+                .map(orderMenu -> orderMenu.getOrder().getId())
+                .toList();
+    }
+
+    private List<OrderMenu> getOrderMenus(User user) {
+        List<Store> findStores = storeRepository.findByUser_UserId(user.getUserId());
+
+        List<UUID> storeIds = findStores.stream()
+                .map(Store::getStoreId)
+                .toList();
+
+        return orderMenuRepository.findOrderMenusByStoreIdIn(storeIds);
+    }
+
+    private User getUserBy(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #17 

## 📝 Description

- 사장은 본인 가게의 주문 목록을 조회할 수 있어야 합니다.
- 주문 Id, 상태, 타입, 고객의 개인 정보 및 주소, 주문 목록, 총 금액 등의 정보를 전달 받습니다.
- `ROLE_OWNER` 만 접근이 가능합니다.

![스크린샷 2024-11-15 오전 3 23 25](https://github.com/user-attachments/assets/efbe683f-d0a8-4d8f-b664-f8477c19e5a4)

- @Secured 어노테이션 사용을 위해 `SecurityConfig` 에 `@EnableMethodSecurity(securedEnabled = true)` 추가해주었습니다.