### PR TITLE
권한에 따른 행동 제약 및 keyword로 검색 고도화

### DIFF
--- a/src/main/java/com/sparta/gitandrun/category/controller/CategoryController.java
+++ b/src/main/java/com/sparta/gitandrun/category/controller/CategoryController.java
@@ -5,6 +5,7 @@ import com.sparta.gitandrun.category.dto.CategoryRequestDto;
 import com.sparta.gitandrun.category.entity.Category;
 import com.sparta.gitandrun.category.service.CategoryService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -29,6 +30,7 @@ public class CategoryController {
     }
 
     // 새로운 카테고리 추가
+    @Secured("ROLE_ADMIN")
     @PostMapping
     public ResponseEntity<ApiResDto> createCategory(@RequestBody CategoryRequestDto categoryRequest) {
         try {
@@ -42,6 +44,7 @@ public class CategoryController {
     }
 
     // 카테고리 수정
+    @Secured("ROLE_ADMIN")
     @PatchMapping("/{categoryId}")
     public ResponseEntity<ApiResDto> updateCategory(@PathVariable UUID categoryId, @RequestBody CategoryRequestDto categoryRequest) {
         try {
@@ -54,7 +57,8 @@ public class CategoryController {
         }
     }
 
-    // 카테고리 삭제 (옵션)
+    // 카테고리 삭제
+    @Secured("ROLE_ADMIN")
     @DeleteMapping("/{categoryId}")
     public ResponseEntity<ApiResDto> deleteCategory(@PathVariable UUID categoryId) {
         try {

--- a/src/main/java/com/sparta/gitandrun/region/controller/RegionController.java
+++ b/src/main/java/com/sparta/gitandrun/region/controller/RegionController.java
@@ -6,6 +6,7 @@ import com.sparta.gitandrun.region.entity.Region;
 import com.sparta.gitandrun.region.service.RegionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,7 +21,8 @@ public class RegionController {
         this.regionService = regionService;
     }
 
-    // JSON 형식으로 데이터를 받아 지역 생성
+    // 지역 생성
+    @Secured("ROLE_ADMIN")
     @PostMapping
     public ResponseEntity<?> createRegion(@RequestBody RegionRequestDto regionRequest) {
         try {
@@ -53,7 +55,8 @@ public class RegionController {
                         .body(new ApiResDto("해당 ID를 가진 지역을 찾을 수 없습니다: " + regionId, 404)));
     }
 
-    // JSON 형식으로 데이터를 받아 지역 수정
+    // 지역 수정
+    @Secured("ROLE_ADMIN")
     @PutMapping("/{regionId}")
     public ResponseEntity<ApiResDto> updateRegion(@PathVariable Long regionId,
                                                   @RequestBody RegionRequestDto regionRequest) {
@@ -69,7 +72,8 @@ public class RegionController {
         }
     }
 
-    // ID로 지역 삭제
+    // 지역 삭제
+    @Secured("ROLE_ADMIN")
     @DeleteMapping("/{regionId}")
     public ResponseEntity<ApiResDto> deleteRegion(@PathVariable Long regionId) {
         try {

--- a/src/main/java/com/sparta/gitandrun/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/gitandrun/store/controller/StoreController.java
@@ -8,6 +8,7 @@ import com.sparta.gitandrun.user.entity.Role;
 import com.sparta.gitandrun.user.jwt.JwtUtil;
 import com.sparta.gitandrun.user.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -196,15 +197,15 @@ public class StoreController {
             @RequestParam(defaultValue = "10") int size) {
 
         try {
-            ApiResDto response = new ApiResDto("검색 성공", 200,
-                    storeService.searchStoresByKeyword(keyword, sortField, page, size, true));
+            Page<?> searchResults = storeService.searchStoresByKeyword(keyword, sortField, page, size, true);
+            ApiResDto response = new ApiResDto("검색 성공", 200, searchResults);
             return ResponseEntity.ok(response);
         } catch (Exception e) {
             return ResponseEntity.status(500).body(new ApiResDto("검색 중 오류 발생", 500));
         }
     }
 
-    // 키워드로 검색
+    // 키워드로 검색 (일반 사용자용)
     @GetMapping("/search/keyword")
     public ResponseEntity<ApiResDto> searchStoresByKeyword(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -215,13 +216,14 @@ public class StoreController {
 
         try {
             boolean isAdmin = userDetails.getUser().getRole().equals(Role.ADMIN);
-            ApiResDto response = new ApiResDto("검색 성공", 200,
-                    storeService.searchStoresByKeyword(keyword, sortField, page, size, isAdmin));
+            Page<?> searchResults = storeService.searchStoresByKeyword(keyword, sortField, page, size, isAdmin);
+            ApiResDto response = new ApiResDto("검색 성공", 200, searchResults);
             return ResponseEntity.ok(response);
         } catch (Exception e) {
             return ResponseEntity.status(500).body(new ApiResDto("검색 중 오류 발생", 500));
         }
     }
+
 
     // 지역 이름으로 가게 조회
     @GetMapping("/search/region")

--- a/src/main/java/com/sparta/gitandrun/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/gitandrun/store/controller/StoreController.java
@@ -2,9 +2,16 @@ package com.sparta.gitandrun.store.controller;
 
 import com.sparta.gitandrun.common.entity.ApiResDto;
 import com.sparta.gitandrun.store.dto.StoreRequestDto;
+import com.sparta.gitandrun.store.entity.Store;
 import com.sparta.gitandrun.store.service.StoreService;
+import com.sparta.gitandrun.user.entity.Role;
+import com.sparta.gitandrun.user.jwt.JwtUtil;
+import com.sparta.gitandrun.user.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -12,112 +19,207 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/store")
+@RequiredArgsConstructor
 public class StoreController {
 
     private final StoreService storeService;
+    private final JwtUtil jwtUtil;
 
-    public StoreController(StoreService storeService) {
-        this.storeService = storeService;
-    }
-
-    // 가게 등록
-    @PostMapping
-    public ResponseEntity<ApiResDto> createStore(@RequestParam Long userId, @RequestBody StoreRequestDto storeRequestDto) {
+    @Secured("ROLE_ADMIN")
+    @PostMapping("/admin")
+    public ResponseEntity<ApiResDto> createStore(
+            @RequestBody StoreRequestDto storeRequestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
-            storeService.createStore(userId, storeRequestDto);
-            ApiResDto response = new ApiResDto("가게가 성공적으로 등록되었습니다.", 201, null);
-            return ResponseEntity.status(201).body(response);
-        } catch (IllegalArgumentException e) {
-            ApiResDto errorResponse = new ApiResDto("가게 생성 권한이 없습니다.", 403);
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
+            // 현재 로그인한 사용자의 ID 가져오기
+            Long userId = userDetails.getUser().getUserId();
+
+            // 가게 등록 요청
+            Store createdStore = storeService.createStore(userId, storeRequestDto);
+
+            // 성공 응답
+            ApiResDto response = new ApiResDto("가게가 성공적으로 등록되었습니다.", 201, createdStore);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (Exception e) {
+            // 예외 처리
+            ApiResDto errorResponse = new ApiResDto("요청 처리 중 오류가 발생했습니다.", 500);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
         }
     }
 
+    // ADMIN 전체 가게 조회
+    @Secured("ROLE_ADMIN")
+    @GetMapping("/admin")
+    public ResponseEntity<ApiResDto> getAllStores() {
+        try {
+            // 전체 가게 조회
+            var stores = storeService.getAllStoresForAdmin();
+            // 성공 응답 반환
+            ApiResDto response = new ApiResDto("전체 가게 조회 성공", 200, stores);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            // 예외 발생 시 오류 응답
+            ApiResDto errorResponse = new ApiResDto("전체 가게 조회 중 오류가 발생했습니다.", 500);
+            return ResponseEntity.status(500).body(errorResponse);
+        }
+    }
 
+    // ~ Admin 전체 가게 조회
+    @GetMapping()
+    public ResponseEntity<ApiResDto> getAllStoresForUser() {
+        try {
+            // 일반 사용자를 위한 전체 가게 조회
+            var stores = storeService.getAllStoresForUser();
+            // 성공 응답 반환
+            ApiResDto response = new ApiResDto("전체 가게 조회 성공", 200, stores);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            // 예외 발생 시 오류 응답
+            ApiResDto errorResponse = new ApiResDto("전체 가게 조회 중 오류가 발생했습니다.", 500);
+            return ResponseEntity.status(500).body(errorResponse);
+        }
+    }
 
-    // ID로 조회
+    // 가게 상세 정보 조회 (권한에 따라 다른 정보 제공)
     @GetMapping("/{storeId}")
-    public ResponseEntity<?> getStoreDetails(
+    public ResponseEntity<?> getStoreDetails(@PathVariable UUID storeId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        Long userId = userDetails.getUser().getUserId(); // 로그인한 유저의 userId
+
+        return storeService.getStoreDetails(storeId, userId);  // 권한에 맞는 가게 정보 반환
+    }
+
+    // 관리자용 가게 수정
+    @Secured("ROLE_ADMIN")
+    @PatchMapping("/admin/{storeId}")
+    public ResponseEntity<ApiResDto> updateStoreByAdmin(
             @PathVariable UUID storeId,
-            @RequestParam Long userId) {
+            @RequestBody StoreRequestDto storeRequestDto) {
         try {
-            return storeService.getStoreDetails(storeId, userId);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ApiResDto("가게 또는 사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()));
+            storeService.updateStoreByAdmin(storeId, storeRequestDto);
+            ApiResDto response = new ApiResDto("가게가 성공적으로 수정되었습니다.", HttpStatus.OK.value());
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            ApiResDto errorResponse = new ApiResDto("가게 수정 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
         }
     }
 
-    // 전체 가게 조회
-    @GetMapping
-    public ResponseEntity<?> getAllStores(@RequestParam Long userId) {
-        try {
-            return ResponseEntity.ok(storeService.getAllStores(userId));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ApiResDto("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()));
-        }
-    }
-
-    // 가게 수정
+    // 일반 사용자용 가게 수정
+    @Secured("ROLE_OWNER")
     @PatchMapping("/{storeId}")
-    public ResponseEntity<ApiResDto> updateStore(
+    public ResponseEntity<ApiResDto> updateStoreByUser(
             @PathVariable UUID storeId,
-            @RequestParam Long userId,
-            @RequestBody StoreRequestDto updatedStoreDto) {
+            @RequestBody StoreRequestDto storeRequestDto) {
         try {
-            storeService.updateStore(storeId, userId, updatedStoreDto);
-            return ResponseEntity.ok(new ApiResDto("가게 정보가 성공적으로 수정되었습니다.", HttpStatus.OK.value()));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(new ApiResDto("수정 권한이 없습니다.", HttpStatus.FORBIDDEN.value()));
+            storeService.updateStoreByUser(storeId, storeRequestDto);
+            ApiResDto response = new ApiResDto("가게가 성공적으로 수정되었습니다.", HttpStatus.OK.value());
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            ApiResDto errorResponse = new ApiResDto("가게 수정 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
         }
     }
 
-    // 가게 삭제
+    // 관리자용 가게 소프트 딜리트
+    @Secured("ROLE_ADMIN")
+    @DeleteMapping("/admin/{storeId}")
+    public ResponseEntity<ApiResDto> softDeleteStoreByAdmin(@PathVariable UUID storeId) {
+        try {
+            storeService.softDeleteStoreByAdmin(storeId);
+            ApiResDto response = new ApiResDto("가게가 성공적으로 삭제되었습니다.", HttpStatus.OK.value());
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            ApiResDto errorResponse = new ApiResDto("가게 삭제 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+        }
+    }
+
+    // 사용자용 가게 소프트 딜리트
+    @Secured("ROLE_OWNER")
     @DeleteMapping("/{storeId}")
-    public ResponseEntity<ApiResDto> deleteStore(
+    public ResponseEntity<ApiResDto> softDeleteStoreByUser(
             @PathVariable UUID storeId,
             @RequestParam Long userId) {
         try {
-            storeService.deleteStore(storeId, userId);
-            return ResponseEntity.ok(new ApiResDto("가게가 성공적으로 삭제되었습니다.", HttpStatus.OK.value()));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(new ApiResDto("삭제 권한이 없습니다.", HttpStatus.FORBIDDEN.value()));
+            storeService.softDeleteStoreByOwner(storeId, userId);
+            ApiResDto response = new ApiResDto("가게가 성공적으로 삭제되었습니다.", HttpStatus.OK.value());
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            ApiResDto errorResponse = new ApiResDto("가게 삭제 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
         }
     }
 
-    // 카테고리로 검색
-    @GetMapping("/search")
-    public ResponseEntity<?> searchStores(
-            @RequestParam(required = false) UUID categoryId,
+    // 카테고리로 검색 (관리자용)
+    @Secured("ROLE_ADMIN")
+    @GetMapping("/admin/search/category")
+    public ResponseEntity<ApiResDto> searchStoresByCategoryAsAdmin(
+            @RequestParam UUID categoryId,
             @RequestParam(defaultValue = "createdAt") String sortField,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam Long userId) {
+            @RequestParam(defaultValue = "10") int size) {
+
         try {
-            return ResponseEntity.ok(storeService.searchStores(categoryId, sortField, page, size, userId));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(new ApiResDto("검색 권한이 없습니다.", HttpStatus.FORBIDDEN.value()));
+            ApiResDto response = new ApiResDto("검색 성공", 200,
+                    storeService.searchStoresByCategory(categoryId, sortField, page, size, true));
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(new ApiResDto("검색 중 오류 발생", 500));
+        }
+    }
+
+    // 카테고리로 검색 (사용자용)
+    @GetMapping("/search/category")
+    public ResponseEntity<ApiResDto> searchStoresByCategoryAsUser(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam UUID categoryId,
+            @RequestParam(defaultValue = "createdAt") String sortField,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        try {
+            ApiResDto response = new ApiResDto("검색 성공", 200,
+                    storeService.searchStoresByCategory(categoryId, sortField, page, size, false));
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(new ApiResDto("검색 중 오류 발생", 500));
+        }
+    }
+
+    // 키워드로 검색 (관리자용)
+    @Secured("ROLE_ADMIN")
+    @GetMapping("/admin/search/keyword")
+    public ResponseEntity<ApiResDto> searchStoresByKeywordAsAdmin(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "createdAt") String sortField,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        try {
+            ApiResDto response = new ApiResDto("검색 성공", 200,
+                    storeService.searchStoresByKeyword(keyword, sortField, page, size, true));
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(new ApiResDto("검색 중 오류 발생", 500));
         }
     }
 
     // 키워드로 검색
     @GetMapping("/search/keyword")
-    public ResponseEntity<?> searchStoresByKeyword(
+    public ResponseEntity<ApiResDto> searchStoresByKeyword(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam String keyword,
             @RequestParam(defaultValue = "createdAt") String sortField,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "asc") String sortDirection,
-            @RequestParam Long userId) {
+            @RequestParam(defaultValue = "10") int size) {
+
         try {
-            return ResponseEntity.ok(storeService.searchStoresByKeyword(keyword, sortField, page, size, userId));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(new ApiResDto("검색 권한이 없습니다.", HttpStatus.FORBIDDEN.value()));
+            boolean isAdmin = userDetails.getUser().getRole().equals(Role.ADMIN);
+            ApiResDto response = new ApiResDto("검색 성공", 200,
+                    storeService.searchStoresByKeyword(keyword, sortField, page, size, isAdmin));
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(new ApiResDto("검색 중 오류 발생", 500));
         }
     }
 

--- a/src/main/java/com/sparta/gitandrun/store/dto/StoreRequestDto.java
+++ b/src/main/java/com/sparta/gitandrun/store/dto/StoreRequestDto.java
@@ -3,7 +3,11 @@ package com.sparta.gitandrun.store.dto;
 import com.sparta.gitandrun.store.entity.Address;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 public class StoreRequestDto {
 
     @NotBlank(message = "가게 이름은 필수 입력 항목입니다.")
@@ -12,7 +16,7 @@ public class StoreRequestDto {
     @NotBlank(message = "전화번호는 필수 입력 항목입니다.")
     private String phone;
 
-    @NotNull(message = "카테고리는 필수 입력 항목입니다.")
+    @NotBlank(message = "카테고리 이름은 필수 입력 항목입니다.")
     private String categoryName;  // 카테고리 이름을 String으로 받기
 
     @NotNull(message = "지역 번호는 필수 입력 항목입니다.")
@@ -20,45 +24,4 @@ public class StoreRequestDto {
 
     @NotNull(message = "주소는 필수 입력 항목입니다.")
     private Address address;  // Address 임베디드 클래스를 사용
-
-    // Getter 및 Setter
-    public String getStoreName() {
-        return storeName;
-    }
-
-    public void setStoreName(String storeName) {
-        this.storeName = storeName;
-    }
-
-    public String getPhone() {
-        return phone;
-    }
-
-    public void setPhone(String phone) {
-        this.phone = phone;
-    }
-
-    public String getCategoryName() {
-        return categoryName;
-    }
-
-    public void setCategoryName(String categoryName) {
-        this.categoryName = categoryName;
-    }
-
-    public Address getAddress() {
-        return address;
-    }
-
-    public void setAddress(Address address) {
-        this.address = address;
-    }
-
-    public Long getRegionId() {
-        return regionId;
-    }
-
-    public void setRegionId(Long regionId) {
-        this.regionId = regionId;
-    }
 }

--- a/src/main/java/com/sparta/gitandrun/store/entity/Store.java
+++ b/src/main/java/com/sparta/gitandrun/store/entity/Store.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 public class Store {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "store_id", columnDefinition = "UUID")
     private UUID storeId = UUID.randomUUID();
 
@@ -60,14 +61,13 @@ public class Store {
     @Column(name = "is_deleted")
     private boolean isDeleted = false;
 
-    // Address 임베디드 클래스 적용
     @Embedded
     private Address address;
 
     // User와의 ManyToOne 관계 설정
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    @JsonBackReference  // 순환 참조 방지
+    @JsonBackReference // 순환 참조 방지
     private User user;
 
     @PrePersist

--- a/src/main/java/com/sparta/gitandrun/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/gitandrun/store/repository/StoreRepository.java
@@ -13,23 +13,27 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface StoreRepository extends JpaRepository<Store, UUID> {
-    List<Store> findByisDeletedFalse();
+    List<Store> findByIsDeletedFalse();
     Optional<Store> findById(UUID storeId); // Store의 ID로 조회하는 메서드
     List<Store> findByUser_UserId(Long userId);
 
-    @Query("SELECT s FROM Store s WHERE s.storeName LIKE %:keyword% OR s.address.address LIKE %:keyword%")
-    Page<Store> searchStores(@Param("keyword") String keyword, Pageable pageable);
-
+    @Query("SELECT s FROM Store s WHERE s.category.id = :categoryId")
     Page<Store> findByCategoryId(UUID categoryId, Pageable pageable);
 
-    @Query("SELECT s FROM Store s WHERE s.storeName LIKE %:keyword% OR s.address.address LIKE %:keyword%")
-    Page<Store> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+    @Query("SELECT s FROM Store s WHERE s.category.id = :categoryId AND s.isDeleted = false")
+    Page<Store> findByCategoryIdAndIsDeletedFalse(UUID categoryId, Pageable pageable);
 
-    // 지역 이름으로 가게 검색
+    @Query("SELECT s FROM Store s WHERE s.storeName LIKE %:keyword% OR s.phone LIKE %:keyword%")
+    Page<Store> searchStores(@Param("keyword") String keyword, Pageable pageable);
+
     @Query("SELECT s FROM Store s WHERE s.region.regionName LIKE %:regionName%")
     List<Store> findByRegionName(@Param("regionName") String regionName);
 
-    // 페이징 처리와 함께 지역 이름으로 가게 검색
-    @Query("SELECT s FROM Store s WHERE s.region.regionName LIKE %:regionName%")
-    Page<Store> findByRegionNameWithPagination(@Param("regionName") String regionName, Pageable pageable);
+    @Query("SELECT s FROM Store s WHERE " +
+            "(LOWER(s.storeName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(s.address.address) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(s.address.addressDetail) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(s.category.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+            "AND s.isDeleted = false")
+    Page<Store> searchStoresAndIsDeletedFalse(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/sparta/gitandrun/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/gitandrun/store/repository/StoreRepository.java
@@ -29,11 +29,14 @@ public interface StoreRepository extends JpaRepository<Store, UUID> {
     @Query("SELECT s FROM Store s WHERE s.region.regionName LIKE %:regionName%")
     List<Store> findByRegionName(@Param("regionName") String regionName);
 
-    @Query("SELECT s FROM Store s WHERE " +
-            "(LOWER(s.storeName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+    @Query("SELECT s FROM Store s " +
+            "WHERE (LOWER(s.storeName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "OR LOWER(s.address.address) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "OR LOWER(s.address.addressDetail) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "OR LOWER(s.category.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
-            "AND s.isDeleted = false")
-    Page<Store> searchStoresAndIsDeletedFalse(@Param("keyword") String keyword, Pageable pageable);
+            "AND (:isAdmin = true OR s.isDeleted = false)")
+    Page<Store> searchStoresWithKeywordAndRole(@Param("keyword") String keyword,
+                                               @Param("isAdmin") boolean isAdmin,
+                                               Pageable pageable);
+
 }

--- a/src/main/java/com/sparta/gitandrun/store/service/StoreService.java
+++ b/src/main/java/com/sparta/gitandrun/store/service/StoreService.java
@@ -232,15 +232,13 @@ public class StoreService {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, sortField));
 
-        Page<Store> stores;
-        if (isAdmin) {
-            stores = storeRepository.searchStores(keyword, pageable);
-        } else {
-            stores = storeRepository.searchStoresAndIsDeletedFalse(keyword, pageable);
-        }
+        Page<Store> stores = storeRepository.searchStoresWithKeywordAndRole(keyword, isAdmin, pageable);
 
+        // 관리자와 사용자에 따른 결과 매핑
         return isAdmin ? stores.map(FullStoreResponse::new) : stores.map(LimitedStoreResponse::new);
     }
+
+
 
     // 유저 조회 메서드
 //    private User getUser(Long userId) {

--- a/src/main/java/com/sparta/gitandrun/store/service/StoreService.java
+++ b/src/main/java/com/sparta/gitandrun/store/service/StoreService.java
@@ -20,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.extern.slf4j.Slf4j;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.LinkedHashMap;
 
+@Slf4j
 @Service
 public class StoreService {
 
@@ -42,16 +44,10 @@ public class StoreService {
         this.categoryRepository = categoryRepository;
     }
 
-    // 가게 생성
     @Transactional
     public Store createStore(Long userId, StoreRequestDto storeRequestDto) {
         // 사용자 정보 조회
         User user = getUser(userId);
-
-        // 권한 체크 - ADMIN 또는 OWNER만 가능
-        if (user.getRole() != Role.ADMIN && user.getRole() != Role.OWNER) {
-            throw new IllegalArgumentException("가게 생성 권한이 없습니다.");  // 권한이 없으면 예외 발생
-        }
 
         // 카테고리 이름으로 카테고리 조회
         Category category = categoryRepository.findByName(storeRequestDto.getCategoryName())
@@ -61,90 +57,202 @@ public class StoreService {
         Region region = regionRepository.findById(storeRequestDto.getRegionId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지역입니다."));
 
+        // 새 가게 생성
         Store newStore = new Store();
+
+        // storeId를 UUID로 자동 생성
+        newStore.setStoreId(UUID.randomUUID());
+
+        // 필드 채우기
         populateStoreFields(newStore, storeRequestDto, user.getUserId().toString());
 
         // 카테고리와 지역 설정
-        newStore.setCategory(category);  // Category 설정
-        newStore.setRegion(region);      // Region 설정
+        newStore.setCategory(category);
+        newStore.setRegion(region);
 
+        // created_by와 updated_by에 userId 설정
+        newStore.setCreatedBy(user.getUserId().toString());
+        newStore.setUpdatedBy(user.getUserId().toString());
+
+        // user 설정
+        newStore.setUser(user);
+
+        // 새 가게 저장
         return storeRepository.save(newStore);
     }
 
-
-
-
-    // 전체 가게 조회
-    public List<?> getAllStores(Long userId) {
-        User user = getUser(userId);
-        List<Store> allStores = user.getRole() == Role.ADMIN ?
-                storeRepository.findAll() : storeRepository.findByisDeletedFalse();
-
-        return allStores.stream()
-                .map(store -> user.getRole() == Role.ADMIN ? new FullStoreResponse(store) : new LimitedStoreResponse(store))
-                .collect(Collectors.toList());
+    private void populateStoreFields(Store store, StoreRequestDto storeRequestDto, String userId) {
+        store.setStoreName(storeRequestDto.getStoreName());
+        store.setPhone(storeRequestDto.getPhone());
+        store.setAddress(storeRequestDto.getAddress());
+        store.setCreatedBy(userId);
+        store.setUpdatedBy(userId);
+        store.setCreatedAt(LocalDateTime.now());
+        store.setUpdatedAt(LocalDateTime.now());
     }
 
-    // 가게 상세 정보 조회
-    public ResponseEntity<?> getStoreDetails(UUID storeId, Long userId) {
-        User user = getUser(userId);
-        Store store = getStore(storeId);
-
-        return user.getRole() == Role.ADMIN ?
-                ResponseEntity.ok(new FullStoreResponse(store)) :
-                ResponseEntity.ok(generateLimitedStoreDetails(store));
-    }
-
-    // 가게 수정
-    @Transactional
-    public void updateStore(UUID storeId, Long userId, StoreRequestDto updatedStore) {
-        User user = validateUserWithRoles(userId, Role.ADMIN, Role.OWNER);
-        Store existingStore = getStore(storeId);
-
-        populateStoreFields(existingStore, updatedStore, user.getUserId().toString());
-
-        storeRepository.save(existingStore);
-    }
-
-    // 가게 삭제 (soft delete 방식)
-    @Transactional
-    public boolean deleteStore(UUID storeId, Long userId) {
-        User user = validateUserWithRoles(userId, Role.ADMIN, Role.OWNER);
-        Store store = getStore(storeId);
-
-        store.markAsDeleted(user.getUserId().toString());
-        storeRepository.save(store);
-        return true;
-    }
-
-    // 페이징 및 조건부 정렬 구현
-    public Page<?> searchStores(UUID categoryId, String sortField, int page, int size, Long userId) {
-        User user = getUser(userId);
-
-        Pageable pageable = PageRequest.of(page, size, Sort.by(sortField).descending());
-        Page<Store> stores = storeRepository.findByCategoryId(categoryId, pageable);
-
-        return mapStoreResponse(stores, user.getRole());
-    }
-
-    public Page<Store> searchStoresByKeyword(String keyword, String sortField, int page, int size, Long userId) {
-        User user = getUser(userId);
-
-        // 정렬 설정
-        Sort sort = Sort.by(Sort.Direction.DESC, sortField);
-        Pageable pageable = PageRequest.of(page, size, sort);
-
-        return storeRepository.searchStores(keyword, pageable);
-    }
-
-    // 유저 조회 메서드
     private User getUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
     }
 
-    // 가게 조회 메서드
+    // ADMIN 전체 가게 조회
+    @Transactional(readOnly = true)
+    public List<FullStoreResponse> getAllStoresForAdmin() {
+        // 모든 가게 정보 조회
+        List<Store> stores = storeRepository.findAll();
+        // FullStoreResponse DTO로 변환하여 반환
+        return stores.stream()
+                .map(FullStoreResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    // ~ADMIN 전체 가게 조회
+    @Transactional(readOnly = true)
+    public List<LimitedStoreResponse> getAllStoresForUser() {
+        // Soft-delete되지 않은 가게만 조회
+        List<Store> stores = storeRepository.findByIsDeletedFalse();
+        // LimitedStoreResponse DTO로 변환하여 반환
+        return stores.stream()
+                .map(LimitedStoreResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    // 가게 상세 정보 조회 (로그인한 유저의 권한에 따라 다르게 응답)
+    @Transactional(readOnly = true)
+    public ResponseEntity<?> getStoreDetails(UUID storeId, Long userId) {
+        User user = getUser(userId); // 로그인한 유저 조회
+        Store store = getStore(storeId); // 가게 정보 조회
+
+        // 유저의 역할에 따라 FullStoreResponse 또는 LimitedStoreResponse 반환
+        if (user.getRole() == Role.ADMIN) {
+            return ResponseEntity.ok(new FullStoreResponse(store)); // 관리자일 경우 모든 정보 제공
+        } else {
+            return ResponseEntity.ok(generateLimitedStoreDetails(store)); // 그 외 유저는 제한된 정보만 제공
+        }
+    }
+
+    // 관리자 가게 수정
+    @Transactional
+    public void updateStoreByAdmin(UUID storeId, StoreRequestDto storeRequestDto) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new IllegalArgumentException("가게를 찾을 수 없습니다."));
+
+        // 모든 필드 수정 가능
+        store.setStoreName(storeRequestDto.getStoreName());
+        store.setPhone(storeRequestDto.getPhone());
+        store.setAddress(storeRequestDto.getAddress());
+
+        if (storeRequestDto.getCategoryName() != null) {
+            Category category = categoryRepository.findByName(storeRequestDto.getCategoryName())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다."));
+            store.setCategory(category);
+        }
+
+        if (storeRequestDto.getRegionId() != null) {
+            Region region = regionRepository.findById(storeRequestDto.getRegionId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지역입니다."));
+            store.setRegion(region);
+        }
+    }
+
+    // 가게 수정
+    @Transactional
+    public void updateStoreByUser(UUID storeId, StoreRequestDto storeRequestDto) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new IllegalArgumentException("가게를 찾을 수 없습니다."));
+
+        // 제한된 필드만 수정 가능
+        if (storeRequestDto.getStoreName() != null) {
+            store.setStoreName(storeRequestDto.getStoreName());
+        }
+        if (storeRequestDto.getPhone() != null) {
+            store.setPhone(storeRequestDto.getPhone());
+        }
+        if (storeRequestDto.getAddress() != null) {
+            store.setAddress(storeRequestDto.getAddress());
+        }
+    }
+
+    // ADMIN 권한으로 삭제
+    @Transactional
+    public void softDeleteStoreByAdmin(UUID storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new IllegalArgumentException("가게를 찾을 수 없습니다."));
+
+        markAsDeleted(store, "ADMIN");
+    }
+
+    // Owner 권한으로 삭제
+    @Transactional
+    public void softDeleteStoreByOwner(UUID storeId, Long userId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new IllegalArgumentException("가게를 찾을 수 없습니다."));
+
+        if (!store.getUser().getUserId().equals(userId)) {
+            throw new IllegalArgumentException("본인이 소유한 가게만 삭제할 수 있습니다.");
+        }
+
+        markAsDeleted(store, userId.toString());
+    }
+
+    // Delete
+    private void markAsDeleted(Store store, String deletedBy) {
+        store.setDeletedBy(deletedBy);
+        store.setDeletedAt(LocalDateTime.now());
+        store.setDeleted(true); // Soft delete 플래그 설정
+        storeRepository.save(store); // 변경된 상태 저장
+    }
+
+    // 카테고리로 검색
+    public Page<?> searchStoresByCategory(UUID categoryId, String sortField, int page, int size, boolean isAdmin) {
+        validatePageSize(size);
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, sortField));
+
+        Page<Store> stores;
+        if (isAdmin) {
+            stores = storeRepository.findByCategoryId(categoryId, pageable);
+        } else {
+            stores = storeRepository.findByCategoryIdAndIsDeletedFalse(categoryId, pageable);
+        }
+
+        return isAdmin ? stores.map(FullStoreResponse::new) : stores.map(LimitedStoreResponse::new);
+    }
+
+
+    private void validatePageSize(int size) {
+        if (size != 10 && size != 30 && size != 50) {
+            throw new IllegalArgumentException("허용되지 않는 페이지 크기입니다. (10, 30, 50 중 하나만 가능합니다)");
+        }
+    }
+
+    public Page<?> searchStoresByKeyword(String keyword, String sortField, int page, int size, boolean isAdmin) {
+        validatePageSize(size);
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, sortField));
+
+        Page<Store> stores;
+        if (isAdmin) {
+            stores = storeRepository.searchStores(keyword, pageable);
+        } else {
+            stores = storeRepository.searchStoresAndIsDeletedFalse(keyword, pageable);
+        }
+
+        return isAdmin ? stores.map(FullStoreResponse::new) : stores.map(LimitedStoreResponse::new);
+    }
+
+    // 유저 조회 메서드
+//    private User getUser(Long userId) {
+//        return userRepository.findById(userId)
+//                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+//    }
+
+    // Store 조회 메서드 (storeId로 조회)
     private Store getStore(UUID storeId) {
+        if (storeId == null) {
+            throw new IllegalArgumentException("storeId는 null일 수 없습니다.");
+        }
         return storeRepository.findById(storeId)
                 .orElseThrow(() -> new IllegalArgumentException("가게를 찾을 수 없습니다."));
     }
@@ -181,25 +289,25 @@ public class StoreService {
                 stores.map(LimitedStoreResponse::new);
     }
 
-    private void populateStoreFields(Store store, StoreRequestDto storeRequestDto, String userId) {
-        if (storeRequestDto.getStoreName() != null) store.setStoreName(storeRequestDto.getStoreName());
-        if (storeRequestDto.getPhone() != null) store.setPhone(storeRequestDto.getPhone());
-
-        // 카테고리 이름이 비어있지 않으면 카테고리 조회 후 설정
-        if (storeRequestDto.getCategoryName() != null && !storeRequestDto.getCategoryName().isEmpty()) {
-            Category category = categoryRepository.findByName(storeRequestDto.getCategoryName())
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다: " + storeRequestDto.getCategoryName()));
-            store.setCategory(category);
-        } else {
-            throw new IllegalArgumentException("카테고리 이름은 필수입니다.");
-        }
-
-        // 주소 처리
-        if (storeRequestDto.getAddress() != null) store.setAddress(storeRequestDto.getAddress());
-
-        store.setUpdatedBy(userId);
-        store.setUpdatedAt(LocalDateTime.now());
-    }
+//    private void populateStoreFields(Store store, StoreRequestDto storeRequestDto, String userId) {
+//        if (storeRequestDto.getStoreName() != null) store.setStoreName(storeRequestDto.getStoreName());
+//        if (storeRequestDto.getPhone() != null) store.setPhone(storeRequestDto.getPhone());
+//
+//        // 카테고리 이름이 비어있지 않으면 카테고리 조회 후 설정
+//        if (storeRequestDto.getCategoryName() != null && !storeRequestDto.getCategoryName().isEmpty()) {
+//            Category category = categoryRepository.findByName(storeRequestDto.getCategoryName())
+//                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다: " + storeRequestDto.getCategoryName()));
+//            store.setCategory(category);
+//        } else {
+//            throw new IllegalArgumentException("카테고리 이름은 필수입니다.");
+//        }
+//
+//        // 주소 처리
+//        if (storeRequestDto.getAddress() != null) store.setAddress(storeRequestDto.getAddress());
+//
+//        store.setUpdatedBy(userId);
+//        store.setUpdatedAt(LocalDateTime.now());
+//    }
 
     // 지역 이름으로 가게 조회
     public List<?> getStoresByRegionName(Long userId, String regionName) {

--- a/src/main/java/com/sparta/gitandrun/user/entity/User.java
+++ b/src/main/java/com/sparta/gitandrun/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.sparta.gitandrun.user.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.sparta.gitandrun.common.entity.BaseEntity;
 import com.sparta.gitandrun.store.entity.Store;
 import jakarta.persistence.*;
@@ -43,6 +44,7 @@ public class User extends BaseEntity {
 
     // User가 Store 정보를 가져올 수 있게 추가
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)  // Store와의 관계 설정
+    @JsonManagedReference // 순환 참조 방지
     private List<Store> stores;
 
     @Column(name = "is_deleted", nullable = false)

--- a/src/main/java/com/sparta/gitandrun/user/service/UserService.java
+++ b/src/main/java/com/sparta/gitandrun/user/service/UserService.java
@@ -82,6 +82,7 @@ public class UserService {
         String encodedPassword = passwordEncoder.encode(password);
         user.updatePassword(encodedPassword, String.valueOf(user.getUserId()));
     }
+
     @Transactional
     public void softDeleteUser(String phone) {
         User user = userRepository.findActiveUserByPhone(phone)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #63 

## 📝 Description
기존에 권한 부여를 어노테이션으로 처리하면서 CRUD에 대해서 관리자 권한에 대한 메서드를 따로 추가한 후 메서드를 다 정리하였습니다.
<img width="662" alt="image" src="https://github.com/user-attachments/assets/78c14db6-4c2e-4b9f-aac7-475fd9d55426">
생성을 ADMIN만 가능하게 요구 사항이 있으므로 이렇게 처리하면서 어노테이션을 추가해줬습니다.

<img width="1031" alt="image" src="https://github.com/user-attachments/assets/7505609c-e387-402d-9d59-50b4a39d2944">
가장 기본적인 Create 부분으로 설명 드리면 로그인 한 토큰으로 헤더에 보내주면 권한을 통해 선별한 후 관리자만 등록이 가능하게 했습니다.

다른 CRUD도 이러한 부분을 기반으로 수정했습니다.

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/59e07482-9df7-43fb-bcbf-1dc0f477f443">
또한 keyword로 검색 부분을 고도화 했습니다. 원래는 가게의 name으로만 검색한 결과가 나왔지만 위의 이미지처럼 서울로 키워드를 설정한 후 검색하면 가게 네임, 주소 등 필드에 상관없이 서울로 설정된 가게들이 나오게 되었습니다.


## 💬 To Reivewers
이상입니다.