### PR TITLE
리뷰 검색 기능 구현

### DIFF
--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -4,10 +4,12 @@ import com.sparta.gitandrun.review.dto.ReviewRequestDto;
 import com.sparta.gitandrun.review.dto.ReviewResponseDto;
 import com.sparta.gitandrun.review.entity.Review;
 import com.sparta.gitandrun.review.service.ReviewService;
-import java.util.List;
+import com.sparta.gitandrun.user.entity.User;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -36,9 +38,12 @@ public class ReviewController {
     }
 
     //리뷰 전체 조회
-    @GetMapping
-    public ResponseEntity<List<ReviewResponseDto>> getAllReviews() {
-        List<ReviewResponseDto> reviews = reviewService.getAllReviews();
+    @GetMapping("/all")
+    public ResponseEntity<Page<ReviewResponseDto>> getAllReviews(
+            @RequestParam(defaultValue="0") int page,
+            @RequestParam(defaultValue="10") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy) {
+        Page<ReviewResponseDto> reviews = reviewService.getAllReviews(page, size, sortBy);
         return ResponseEntity.ok(reviews);
     }
 
@@ -49,24 +54,37 @@ public class ReviewController {
         return ResponseEntity.ok(review);
     }
 
-    //userId로 조회
-    @GetMapping("/{userId}")
-    public ResponseEntity<List<ReviewResponseDto>> getReviewsByUser(@PathVariable Long userId) {
-        List<ReviewResponseDto> reviews = reviewService.getReviewsByUser(userId);
+    //현재 로그인한 사용자가 쓴 리뷰 조회
+    @GetMapping("/my-reviews")
+    public ResponseEntity<Page<ReviewResponseDto>> getReviewsByCurrentUser(
+            @AuthenticationPrincipal User user,  // 로그인한 사용자 정보를 가져옴
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy) {
+        // 로그인한 사용자의 ID를 이용해 해당 사용자의 리뷰를 조회
+        Page<ReviewResponseDto> reviews = reviewService.getReviewsByUser(user.getUserId(), page, size, sortBy);
         return ResponseEntity.ok(reviews);
     }
 
     //storeId로 조회
     @GetMapping("/{storeId}")
-    public ResponseEntity<List<ReviewResponseDto>> getReviewsByStore(@PathVariable UUID storeId) {
-        List<ReviewResponseDto> reviews = reviewService.getReviewsByStore(storeId);
+    public ResponseEntity<Page<ReviewResponseDto>> getReviewsByStore(
+            @PathVariable UUID storeId,
+            @RequestParam(defaultValue="0") int page,
+            @RequestParam(defaultValue="10") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy) {
+        Page<ReviewResponseDto> reviews = reviewService.getReviewsByStore(storeId, page, size, sortBy);
         return ResponseEntity.ok(reviews);
     }
 
     //reviewContent에서 키워드로 검색
     @GetMapping("/search")
-    public ResponseEntity<List<ReviewResponseDto>> getReviewsByKeyword(@RequestParam String keyword) {
-        List<ReviewResponseDto> reviews = reviewService.getReviewsByKeyword(keyword);
+    public ResponseEntity<Page<ReviewResponseDto>> getReviewsByKeyword(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue="0") int page,
+            @RequestParam(defaultValue="10") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy) {
+        Page<ReviewResponseDto> reviews = reviewService.getReviewsByKeyword(keyword, page, size, sortBy);
         return ResponseEntity.ok(reviews);
     }
 

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -26,7 +26,7 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     //리뷰 작성
-    @PostMapping
+    @PostMapping("/write")
     public ResponseEntity<ReviewResponseDto> createReview(
             @RequestBody ReviewRequestDto requestDto,
             @RequestParam Long userId,

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -56,6 +56,13 @@ public class ReviewController {
         return ResponseEntity.ok(reviews);
     }
 
+    //storeId로 조회
+    @GetMapping("/{storeId}")
+    public ResponseEntity<List<ReviewResponseDto>> getReviewsByStore(@PathVariable UUID storeId) {
+        List<ReviewResponseDto> reviews = reviewService.getReviewsByStore(storeId);
+        return ResponseEntity.ok(reviews);
+    }
+
     //reviewContent에서 키워드로 검색
     @GetMapping("/search")
     public ResponseEntity<List<ReviewResponseDto>> getReviewsByKeyword(@RequestParam String keyword) {

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -35,35 +35,7 @@ public class ReviewController {
         return ResponseEntity.ok(new ReviewResponseDto(review));
     }
 
-    //리뷰 전체 조회
-    @GetMapping("/all")
-    public ResponseEntity<Page<ReviewResponseDto>> getAllReviews(
-            @RequestParam(defaultValue="0") int page,
-            @RequestParam(defaultValue="10") int size,
-            @RequestParam(defaultValue = "createdAt") String sortBy) {
-        Page<ReviewResponseDto> reviews = reviewService.getAllReviews(page, size, sortBy);
-        return ResponseEntity.ok(reviews);
-    }
-
-    //리뷰 단일 조회
-    @GetMapping("/reviewId/{reviewId}")
-    public ResponseEntity<ReviewResponseDto> getOneReview(@PathVariable UUID reviewId) {
-        ReviewResponseDto review = reviewService.getOneReview(reviewId);
-        return ResponseEntity.ok(review);
-    }
-
-    //userId로 조회
-    @GetMapping("/userId/{userId}")
-    public ResponseEntity<Page<ReviewResponseDto>> getReviewsByUser(
-            @PathVariable Long userId,
-            @RequestParam(defaultValue="0") int page,
-            @RequestParam(defaultValue="10") int size,
-            @RequestParam(defaultValue = "createdAt") String sortBy) {
-        Page<ReviewResponseDto> reviews = reviewService.getReviewsByUser(userId, page, size, sortBy);
-        return ResponseEntity.ok(reviews);
-    }
-
-    //storeId로 조회
+    //공통 - 가게별 리뷰 조회
     @GetMapping("/storeId/{storeId}")
     public ResponseEntity<Page<ReviewResponseDto>> getReviewsByStore(
             @PathVariable UUID storeId,
@@ -74,7 +46,35 @@ public class ReviewController {
         return ResponseEntity.ok(reviews);
     }
 
-    //reviewContent에서 키워드로 검색
+    // 사용자 - 본인 리뷰 조회
+    @GetMapping("/userId/{userId}")
+    public ResponseEntity<Page<ReviewResponseDto>> getReviewsByUser(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue="0") int page,
+            @RequestParam(defaultValue="10") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy) {
+        Page<ReviewResponseDto> reviews = reviewService.getReviewsByUser(userId, page, size, sortBy);
+        return ResponseEntity.ok(reviews);
+    }
+
+    // 관리자 - 모든 리뷰 조회
+    @GetMapping("/all")
+    public ResponseEntity<Page<ReviewResponseDto>> getAllReviews(
+            @RequestParam(defaultValue="0") int page,
+            @RequestParam(defaultValue="10") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy) {
+        Page<ReviewResponseDto> reviews = reviewService.getAllReviews(page, size, sortBy);
+        return ResponseEntity.ok(reviews);
+    }
+
+    // 관리자 - 리뷰 아이디로 조회
+    @GetMapping("/reviewId/{reviewId}")
+    public ResponseEntity<ReviewResponseDto> getOneReview(@PathVariable UUID reviewId) {
+        ReviewResponseDto review = reviewService.getOneReview(reviewId);
+        return ResponseEntity.ok(review);
+    }
+
+    // 관리자 - 키워드로 리뷰 검색
     @GetMapping("/search")
     public ResponseEntity<Page<ReviewResponseDto>> getReviewsByKeyword(
             @RequestParam String keyword,

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -56,6 +56,13 @@ public class ReviewController {
         return ResponseEntity.ok(reviews);
     }
 
+    //reviewContent에서 키워드로 검색
+    @GetMapping("/search")
+    public ResponseEntity<List<ReviewResponseDto>> getReviewsByKeyword(@RequestParam String keyword) {
+        List<ReviewResponseDto> reviews = reviewService.getReviewsByKeyword(keyword);
+        return ResponseEntity.ok(reviews);
+    }
+
     //리뷰 수정
     @PatchMapping("/{reviewId}")
     public ResponseEntity<String> updateReview(@PathVariable UUID reviewId,

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -49,6 +49,13 @@ public class ReviewController {
         return ResponseEntity.ok(review);
     }
 
+    //userId로 조회
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<ReviewResponseDto>> getReviewsByUser(@PathVariable Long userId) {
+        List<ReviewResponseDto> reviews = reviewService.getReviewsByUser(userId);
+        return ResponseEntity.ok(reviews);
+    }
+
     //리뷰 수정
     @PatchMapping("/{reviewId}")
     public ResponseEntity<String> updateReview(@PathVariable UUID reviewId,

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -4,12 +4,10 @@ import com.sparta.gitandrun.review.dto.ReviewRequestDto;
 import com.sparta.gitandrun.review.dto.ReviewResponseDto;
 import com.sparta.gitandrun.review.entity.Review;
 import com.sparta.gitandrun.review.service.ReviewService;
-import com.sparta.gitandrun.user.entity.User;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -48,26 +46,25 @@ public class ReviewController {
     }
 
     //리뷰 단일 조회
-    @GetMapping("/{reviewId}")
+    @GetMapping("/reviewId/{reviewId}")
     public ResponseEntity<ReviewResponseDto> getOneReview(@PathVariable UUID reviewId) {
         ReviewResponseDto review = reviewService.getOneReview(reviewId);
         return ResponseEntity.ok(review);
     }
 
-    //현재 로그인한 사용자가 쓴 리뷰 조회
-    @GetMapping("/my-reviews")
-    public ResponseEntity<Page<ReviewResponseDto>> getReviewsByCurrentUser(
-            @AuthenticationPrincipal User user,  // 로그인한 사용자 정보를 가져옴
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
+    //userId로 조회
+    @GetMapping("/userId/{userId}")
+    public ResponseEntity<Page<ReviewResponseDto>> getReviewsByUser(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue="0") int page,
+            @RequestParam(defaultValue="10") int size,
             @RequestParam(defaultValue = "createdAt") String sortBy) {
-        // 로그인한 사용자의 ID를 이용해 해당 사용자의 리뷰를 조회
-        Page<ReviewResponseDto> reviews = reviewService.getReviewsByUser(user.getUserId(), page, size, sortBy);
+        Page<ReviewResponseDto> reviews = reviewService.getReviewsByUser(userId, page, size, sortBy);
         return ResponseEntity.ok(reviews);
     }
 
     //storeId로 조회
-    @GetMapping("/{storeId}")
+    @GetMapping("/storeId/{storeId}")
     public ResponseEntity<Page<ReviewResponseDto>> getReviewsByStore(
             @PathVariable UUID storeId,
             @RequestParam(defaultValue="0") int page,

--- a/src/main/java/com/sparta/gitandrun/review/entity/Review.java
+++ b/src/main/java/com/sparta/gitandrun/review/entity/Review.java
@@ -45,7 +45,7 @@ public class Review extends BaseEntity {
     @Column(name = "review_rating", nullable = false)
     private Short reviewRating;
 
-    @Column(name = "is_deleted")
+    @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 
     public Review(ReviewRequestDto requestDto, User user, UUID storeId, Order order) {

--- a/src/main/java/com/sparta/gitandrun/review/entity/Review.java
+++ b/src/main/java/com/sparta/gitandrun/review/entity/Review.java
@@ -1,36 +1,28 @@
 package com.sparta.gitandrun.review.entity;
 
+import com.sparta.gitandrun.common.entity.BaseEntity;
 import com.sparta.gitandrun.review.dto.ReviewRequestDto;
 import com.sparta.gitandrun.order.entity.Order;
 import com.sparta.gitandrun.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.PreRemove;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.SoftDelete;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @Setter
-@EntityListeners(AuditingEntityListener.class)
-@SoftDelete(columnName = "is_deleted")
 @NoArgsConstructor
 @Table(name = "p_review")
-public class Review {
+public class Review extends BaseEntity {
 
     @Id
     @Column(name = "review_id")
@@ -53,35 +45,8 @@ public class Review {
     @Column(name = "review_rating", nullable = false)
     private Short reviewRating;
 
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "created_by", nullable = false, length = 30, updatable = false)
-    protected String createdBy;
-
-    @LastModifiedDate
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @Column(name = "updated_by", nullable = false, length = 30)
-    protected String updatedBy;
-
-    @Column(name = "is_deleted", insertable = false, updatable = false)
-    private boolean isDeleted;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
-    @Column(name = "deleted_by", length = 30)
-    private String deletedBy;
-
-    @PreRemove
-    public void preRemove() {
-        this.isDeleted = true;
-        this.deletedAt = LocalDateTime.now();
-        this.deletedBy = String.valueOf(user.getUserId());
-    }
+    @Column(name = "is_deleted")
+    private boolean isDeleted = false;
 
     public Review(ReviewRequestDto requestDto, User user, UUID storeId, Order order) {
         this.user = user;
@@ -89,7 +54,5 @@ public class Review {
         this.order = order;
         this.reviewContent = requestDto.getReviewContent();
         this.reviewRating = requestDto.getReviewRating();
-        this.createdBy = String.valueOf(user.getUserId());
-        this.updatedBy = String.valueOf(user.getUserId());
     }
 }

--- a/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
@@ -15,4 +15,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     List<Review> findByUser(User userId);
 
     List<Review> findByStoreId(UUID storeId);
+
+    List<Review> findByReviewContentContaining(String keyword);
 }

--- a/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.gitandrun.review.repository;
 
 import com.sparta.gitandrun.review.entity.Review;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
@@ -8,4 +10,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
     // 해당 주문에 리뷰가 이미 존재하는지 확인
     boolean existsByOrderId(Long orderId);
+
+    List<Review> findById(Long userId);
 }

--- a/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.gitandrun.review.repository;
 
 import com.sparta.gitandrun.review.entity.Review;
+import com.sparta.gitandrun.user.entity.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,5 +12,5 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     // 해당 주문에 리뷰가 이미 존재하는지 확인
     boolean existsByOrderId(Long orderId);
 
-    List<Review> findById(Long userId);
+    List<Review> findByUser(User userId);
 }

--- a/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
@@ -2,8 +2,8 @@ package com.sparta.gitandrun.review.repository;
 
 import com.sparta.gitandrun.review.entity.Review;
 import com.sparta.gitandrun.user.entity.User;
-import java.util.List;
-import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
@@ -12,9 +12,9 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     // 해당 주문에 리뷰가 이미 존재하는지 확인
     boolean existsByOrderId(Long orderId);
 
-    List<Review> findByUser(User userId);
+    Page<Review> findByUser(User user, Pageable pageable);
 
-    List<Review> findByStoreId(UUID storeId);
+    Page<Review> findByStoreId(UUID storeId, Pageable pageable);
 
-    List<Review> findByReviewContentContaining(String keyword);
+    Page<Review> findByReviewContentContaining(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
@@ -13,4 +13,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     boolean existsByOrderId(Long orderId);
 
     List<Review> findByUser(User userId);
+
+    List<Review> findByStoreId(UUID storeId);
 }

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -58,10 +58,19 @@ public class ReviewService {
                 .collect(Collectors.toList());
     }
 
-    //리뷰 단일 조회
+    //리뷰 아이디로 조회
     public ReviewResponseDto getOneReview(UUID reviewId) {
         Review review = getReview(reviewId);
         return new ReviewResponseDto(review);
+    }
+
+    //userId로 조회
+    public List<ReviewResponseDto> getReviewsByUser(Long userId) {
+        User user = getUser(userId);
+        List<Review> reviews = reviewRepository.findById(userId);
+        return reviews.stream()
+                .map(ReviewResponseDto::new)
+                .collect(Collectors.toList());
     }
 
     //리뷰 수정

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -55,7 +55,7 @@ public class ReviewService {
     public List<ReviewResponseDto> getAllReviews() {
         return reviewRepository.findAll().stream()
                 .map(ReviewResponseDto::new)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     //리뷰 아이디로 조회
@@ -70,7 +70,15 @@ public class ReviewService {
         List<Review> reviews = reviewRepository.findByUser(user);
         return reviews.stream()
                 .map(ReviewResponseDto::new)
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    //storeId로 조회
+    public List<ReviewResponseDto> getReviewsByStore(UUID storeId) {
+        List<Review> reviews = reviewRepository.findByStoreId(storeId);
+        return reviews.stream()
+                .map(ReviewResponseDto::new)
+                .toList();
     }
 
     //리뷰 수정

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -30,8 +30,7 @@ public class ReviewService {
     //리뷰 작성
     public Review createReview(ReviewRequestDto requestDto, Long userId, Long orderId) {
         // userId로 User 객체 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        User user = getUser(userId);
 
         // orderId로 Order 객체 조회 및 완료된 주문인지 확인
         Order order = orderRepository.findByIdAndOrderStatus(orderId, OrderStatus.COMPLETED)
@@ -61,16 +60,14 @@ public class ReviewService {
 
     //리뷰 단일 조회
     public ReviewResponseDto getOneReview(UUID reviewId) {
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+        Review review = getReview(reviewId);
         return new ReviewResponseDto(review);
     }
 
     //리뷰 수정
     @Transactional
     public void updateReview(UUID reviewId, ReviewRequestDto requestDto) {
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new IllegalArgumentException("리뷰가 존재하지 않습니다."));
+        Review review = getReview(reviewId);
 
         if (requestDto.getReviewContent() != null && !requestDto.getReviewContent().isEmpty()) {
             review.setReviewContent(requestDto.getReviewContent());
@@ -89,5 +86,17 @@ public class ReviewService {
                 .orElseThrow(() -> new IllegalArgumentException("리뷰가 존재하지 않습니다."));
         review.setDeleted(true);
         reviewRepository.save(review);
+    }
+
+    //사용자 확인
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+    }
+
+    //리뷰 확인
+    private Review getReview(UUID reviewId) {
+        return reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -67,7 +67,7 @@ public class ReviewService {
     //userId로 조회
     public List<ReviewResponseDto> getReviewsByUser(Long userId) {
         User user = getUser(userId);
-        List<Review> reviews = reviewRepository.findById(userId);
+        List<Review> reviews = reviewRepository.findByUser(user);
         return reviews.stream()
                 .map(ReviewResponseDto::new)
                 .collect(Collectors.toList());

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -87,6 +87,7 @@ public class ReviewService {
     public void deleteReview(UUID reviewId) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new IllegalArgumentException("리뷰가 존재하지 않습니다."));
-        reviewRepository.delete(review);
+        review.setDeleted(true);
+        reviewRepository.save(review);
     }
 }

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -31,6 +31,7 @@ public class ReviewService {
     private final OrderMenuRepository orderMenuRepository;
 
     //리뷰 작성
+    @Transactional
     public Review createReview(ReviewRequestDto requestDto, Long userId, Long orderId) {
         // userId로 User 객체 조회
         User user = getUser(userId);
@@ -55,6 +56,7 @@ public class ReviewService {
     }
 
     //리뷰 전체 조회
+    @Transactional(readOnly = true)
     public Page<ReviewResponseDto> getAllReviews(int page, int size, String sortBy) {
         Pageable pageable = optionPageable(page, size, sortBy);
         Page<Review> reviews = reviewRepository.findAll(pageable);
@@ -62,12 +64,14 @@ public class ReviewService {
     }
 
     //리뷰 아이디로 조회
+    @Transactional(readOnly = true)
     public ReviewResponseDto getOneReview(UUID reviewId) {
         Review review = getReview(reviewId);
         return new ReviewResponseDto(review);
     }
 
-    //userId로 조회
+    //사용자별 리뷰 조회
+    @Transactional(readOnly = true)
     public Page<ReviewResponseDto> getReviewsByUser(Long userId, int page, int size, String sortBy) {
         User user = getUser(userId);
         Pageable pageable = optionPageable(page, size, sortBy);
@@ -75,14 +79,16 @@ public class ReviewService {
         return reviews.map(ReviewResponseDto::new);
     }
 
-    //storeId로 조회
+    //가게별 리뷰 조회
+    @Transactional(readOnly = true)
     public Page<ReviewResponseDto> getReviewsByStore(UUID storeId, int page, int size, String sortBy) {
         Pageable pageable = optionPageable(page, size, sortBy);
         Page<Review> reviews = reviewRepository.findByStoreId(storeId, pageable);
         return reviews.map(ReviewResponseDto::new);
     }
 
-    //리뷰내용 키워드로 검색
+    //리뷰 내용 키워드로 검색
+    @Transactional(readOnly = true)
     public Page<ReviewResponseDto> getReviewsByKeyword(String keyword, int page, int size, String sortBy) {
         Pageable pageable = optionPageable(page, size, sortBy);
         Page<Review> reviews = reviewRepository.findByReviewContentContaining(keyword, pageable);

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -81,6 +81,14 @@ public class ReviewService {
                 .toList();
     }
 
+    //리뷰내용 키워드로 검색
+    public List<ReviewResponseDto> getReviewsByKeyword(String keyword) {
+        List<Review> reviews = reviewRepository.findByReviewContentContaining(keyword);
+        return reviews.stream()
+                .map(ReviewResponseDto::new)
+                .toList();
+    }
+
     //리뷰 수정
     @Transactional
     public void updateReview(UUID reviewId, ReviewRequestDto requestDto) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #49 

## 📝 Description

- 리뷰 조회에 페이징 기능 추가
- 공통: 가게별 리뷰 조회
- 사용자: 본인 리뷰 조회
- 관리자: 모든 리뷰 조회, 리뷰 아이디로 조회, 키워드로 리뷰 검색
관리자 권한은 아래와 같이 설정했습니다.
<img width="745" alt="스크린샷 2024-11-15 오후 5 41 20" src="https://github.com/user-attachments/assets/4f610a27-ed8b-4415-9664-eb60653cb695">

## 💬 To Reivewers

현재 구현한 기능을 바탕으로, 이후에 "현재 로그인한 사용자의 리뷰 조회"와 "관리자가 특정 사용자의 리뷰 조회"를 각각 별도의 메서드로 나누어 권한을 확인하려고 합니다. 이 부분에 대해 추가적인 의견이나 제안이 있으시면 편하게 말씀해 주세요. 또한, 코드나 구현에 개선할 점이나 이상한 부분이 있다면 언제든지 알려주시면 감사하겠습니다.