### PR TITLE
제한된 가게에 store_Id Res에 추가 및 deleted / not-deleted 검색 기능 추가

### DIFF
--- a/src/main/java/com/sparta/gitandrun/region/controller/RegionController.java
+++ b/src/main/java/com/sparta/gitandrun/region/controller/RegionController.java
@@ -57,7 +57,7 @@ public class RegionController {
 
     // 지역 수정
     @Secured({"ROLE_ADMIN", "ROLE_MANAGER"})
-    @PutMapping("/{regionId}")
+    @PatchMapping("/{regionId}")
     public ResponseEntity<ApiResDto> updateRegion(@PathVariable Long regionId,
                                                   @RequestBody RegionRequestDto regionRequest) {
         try {

--- a/src/main/java/com/sparta/gitandrun/store/dto/LimitedStoreResponse.java
+++ b/src/main/java/com/sparta/gitandrun/store/dto/LimitedStoreResponse.java
@@ -3,8 +3,11 @@ package com.sparta.gitandrun.store.dto;
 import com.sparta.gitandrun.store.entity.Store;
 import lombok.Data;
 
+import java.util.UUID;
+
 @Data
 public class LimitedStoreResponse {
+    private UUID storeId; // storeId 필드 추가
     private String storeName;
     private String phone;
     private String category;
@@ -14,6 +17,7 @@ public class LimitedStoreResponse {
     private Long userId;
 
     public LimitedStoreResponse(Store store) {
+        this.storeId = store.getStoreId();
         this.storeName = store.getStoreName();
         this.phone = store.getPhone();
         this.category = store.getCategory().toString();

--- a/src/main/java/com/sparta/gitandrun/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/gitandrun/store/repository/StoreRepository.java
@@ -13,9 +13,15 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface StoreRepository extends JpaRepository<Store, UUID> {
-    List<Store> findByIsDeletedFalse();
     Optional<Store> findById(UUID storeId); // Store의 ID로 조회하는 메서드
+
     List<Store> findByUser_UserId(Long userId);
+
+    // Soft-Delete된 가게만 조회
+    List<Store> findByIsDeletedTrue();
+
+    // Soft-Delete되지 않은 가게만 조회
+    List<Store> findByIsDeletedFalse();
 
     @Query("SELECT s FROM Store s WHERE s.category.id = :categoryId")
     Page<Store> findByCategoryId(UUID categoryId, Pageable pageable);
@@ -39,4 +45,25 @@ public interface StoreRepository extends JpaRepository<Store, UUID> {
                                                @Param("isAdmin") boolean isAdmin,
                                                Pageable pageable);
 
+    // Soft-Delete된 가게 카테고리로 검색
+    @Query("SELECT s FROM Store s WHERE s.category.id = :categoryId AND s.isDeleted = true")
+    Page<Store> findByCategoryIdAndIsDeletedTrue(@Param("categoryId") UUID categoryId, Pageable pageable);
+
+    // Soft-Delete된 가게 키워드로 검색
+    @Query("SELECT s FROM Store s WHERE " +
+            "(LOWER(s.storeName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(s.address.address) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(s.address.addressDetail) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(s.category.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+            "AND s.isDeleted = true")
+    Page<Store> searchStoresAndIsDeletedTrue(@Param("keyword") String keyword, Pageable pageable);
+
+    // Soft-Delete되지 않은 가게 키워드로 검색
+    @Query("SELECT s FROM Store s WHERE " +
+            "(LOWER(s.storeName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(s.address.address) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(s.address.addressDetail) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(s.category.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+            "AND s.isDeleted = false")
+    Page<Store> searchStoresAndIsDeletedFalse(@Param("keyword") String keyword, Pageable pageable);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #77 

## 📝 Description
이번 PR에서는 가게 관리와 관련된 기능을 개선하고 soft-delete 관리 방식을 확장하는 작업을 진행했습니다. 

### 주요 변경 사항
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/b925cbe8-687c-4243-8db2-2392eef51a62">

1. **Store 조회에 storeId 추가**  
   - 가게 상세 조회, 전체 조회, 제한된 조회 시 `storeId`가 응답에 포함되도록 수정했습니다.
   - JSON 응답에서 `storeId`를 최상단으로 배치하여 가독성을 높였습니다.

2. **Soft-delete 관리 방식 확장**  
<img width="888" alt="image" src="https://github.com/user-attachments/assets/8b71b648-6788-4a95-8beb-d4a509e3baac">

   - 관리자가 soft-delete 된 가게만 조회하거나, soft-delete 되지 않은 가게만 조회할 수 있는 별도의 엔드포인트를 추가했습니다.
   - 일반 사용자나 Owner는 여전히 soft-delete 되지 않은 가게만 조회 가능합니다.

3. **카테고리 및 키워드 검색에 soft-delete 조건 추가**  
<img width="562" alt="image" src="https://github.com/user-attachments/assets/e4e2e4b2-0455-43f7-9757-2bc0cde5f937">

<img width="993" alt="image" src="https://github.com/user-attachments/assets/7ad77aa2-a910-4eca-bea0-fb2c0968c7bf">

   - 관리자는 검색 시 soft-delete 상태에 관계없이 결과를 조회할 수 있습니다.
   - 일반 사용자나 Owner는 soft-delete 되지 않은 데이터만 검색되도록 제한했습니다.
   - soft-delete된 가게만 검색하는 기능 추가 (관리자 전용).

4. **코드 리팩토링 및 최적화**  
   - Soft-delete와 관련된 로직을 재사용할 수 있도록 `StoreRepository`에 쿼리를 통합 및 최적화했습니다.
   - `Service` 계층에서 불필요한 중복 로직을 제거하고 예외 처리 및 가독성을 개선했습니다.

### 추가된 엔드포인트
1. **전체 가게 조회**
   - `/store/admin/all-soft-deleted`  
     - Soft-delete된 가게만 조회 (관리자 전용).
   - `/store/admin/all-not-deleted`  
     - Soft-delete되지 않은 가게만 조회 (관리자 전용).

2. **카테고리 검색**
   - `/store/admin/search/category/soft-deleted`  
     - Soft-delete된 데이터만 카테고리 검색 (관리자 전용).
   - `/store/admin/search/category/not-deleted`  
     - Soft-delete되지 않은 데이터만 카테고리 검색 (관리자 전용).

5. **키워드 검색**
   - `/store/admin/search/keyword/soft-deleted`  
     - Soft-delete된 데이터만 키워드 검색 (관리자 전용).
   - `/store/admin/search/keyword/not-deleted`  
     - Soft-delete되지 않은 데이터만 키워드 검색 (관리자 전용).

### 테스트 및 검증
- 모든 새 엔드포인트가 정상적으로 동작하는지 PostMan테스트 완료.

## 💬 To Reivewers
이상입니다.