### PR TITLE
본인 소유의 삭제된 가게 수정이 가능하던 버그 수정

### DIFF
--- a/src/main/java/com/sparta/gitandrun/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/gitandrun/store/controller/StoreController.java
@@ -170,12 +170,13 @@ public class StoreController {
     }
 
     // 사용자용 가게 소프트 딜리트
-    @Secured({"ROLE_OWNER", "ROLE_MANAGER", "ROLE_ADMIN"})
     @DeleteMapping("/{storeId}")
+    @Secured({"ROLE_OWNER", "ROLE_MANAGER", "ROLE_ADMIN"})
     public ResponseEntity<ApiResDto> softDeleteStoreByUser(
             @PathVariable UUID storeId,
-            @RequestParam Long userId) {
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
+            Long userId = userDetails.getUser().getUserId(); // 인증된 사용자 ID 가져오기
             storeService.softDeleteStoreByOwner(storeId, userId);
             ApiResDto response = new ApiResDto("가게가 성공적으로 삭제되었습니다.", HttpStatus.OK.value());
             return ResponseEntity.ok(response);
@@ -184,6 +185,7 @@ public class StoreController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
         }
     }
+
 
     // 카테고리로 검색 (관리자용)
     @Secured({"ROLE_ADMIN", "ROLE_MANAGER"})

--- a/src/main/java/com/sparta/gitandrun/store/service/StoreService.java
+++ b/src/main/java/com/sparta/gitandrun/store/service/StoreService.java
@@ -188,6 +188,11 @@ public class StoreService {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new IllegalArgumentException("가게를 찾을 수 없습니다."));
 
+        // 삭제된 가게인지 확인
+        if (store.isDeleted()) {
+            throw new IllegalArgumentException("삭제된 가게는 수정할 수 없습니다.");
+        }
+
         // 가게의 소유자와 로그인한 사용자 비교
         if (!store.getUser().getUserId().equals(userId)) {
             throw new IllegalArgumentException("본인이 소유한 가게만 수정할 수 있습니다.");
@@ -214,6 +219,7 @@ public class StoreService {
         store.setUpdatedAt(LocalDateTime.now());
         store.setUpdatedBy(userId.toString());
     }
+
 
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #85 

## 📝 Description
본인 소유의 삭제된 가게 수정이 가능하던 버그 수정

## 💬 To Reivewers
본인 소유의 삭제된 가게 수정이 가능하던 버그 수정했습니다. 또한 가게 수정 시 더 이상 userId를 param으로 받지 않습니다.