### PR TITLE
매니저 결제 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/gitandrun/payment/contoller/PaymentController.java
+++ b/src/main/java/com/sparta/gitandrun/payment/contoller/PaymentController.java
@@ -2,9 +2,10 @@ package com.sparta.gitandrun.payment.contoller;
 
 import com.sparta.gitandrun.common.entity.ApiResDto;
 import com.sparta.gitandrun.order.dto.res.ResDto;
+import com.sparta.gitandrun.payment.dto.req.ReqPaymentCondByManagerDTO;
 import com.sparta.gitandrun.payment.dto.req.ReqPaymentCondDTO;
 import com.sparta.gitandrun.payment.dto.req.ReqPaymentPostDTO;
-import com.sparta.gitandrun.payment.dto.res.ResPaymentGetByCustomerDTO;
+import com.sparta.gitandrun.payment.dto.res.ResPaymentGetByUserIdDTO;
 import com.sparta.gitandrun.payment.service.PaymentService;
 import com.sparta.gitandrun.user.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -38,11 +39,19 @@ public class PaymentController {
 
     @Secured("ROLE_CUSTOMER")
     @GetMapping
-    public ResponseEntity<ResDto<ResPaymentGetByCustomerDTO>> readPayment(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                          @RequestBody ReqPaymentCondDTO condition,
-                                                                          @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public ResponseEntity<ResDto<ResPaymentGetByUserIdDTO>> readPayment(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                        @RequestBody ReqPaymentCondDTO condition,
+                                                                        @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return paymentService.getByCustomer(userDetails.getUser(), condition, pageable);
+    }
+
+    @Secured("ROLE_MANAGER")
+    @GetMapping("/manager")
+    public ResponseEntity<ResDto<ResPaymentGetByUserIdDTO>> readPayment(@RequestBody ReqPaymentCondByManagerDTO condition,
+                                                                        @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return paymentService.getByManager(condition, pageable);
     }
 
     @Secured({"ROLE_CUSTOMER", "ROLE_MANAGER"})

--- a/src/main/java/com/sparta/gitandrun/payment/dto/req/ReqPaymentCondByManagerDTO.java
+++ b/src/main/java/com/sparta/gitandrun/payment/dto/req/ReqPaymentCondByManagerDTO.java
@@ -1,0 +1,32 @@
+package com.sparta.gitandrun.payment.dto.req;
+
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReqPaymentCondByManagerDTO {
+
+    @Valid
+    @NotNull(message = "고객 정보를 입력해주세요")
+    private Customer customer;
+    private Condition condition;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Customer {
+        @NotNull(message = "id 를 입력해주세요.")
+        private Long id;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Condition {
+        private String status;
+        private String sortType;
+        private boolean deleted;
+    }
+}

--- a/src/main/java/com/sparta/gitandrun/payment/dto/res/ResPaymentGetByUserIdDTO.java
+++ b/src/main/java/com/sparta/gitandrun/payment/dto/res/ResPaymentGetByUserIdDTO.java
@@ -19,12 +19,12 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ResPaymentGetByCustomerDTO {
+public class ResPaymentGetByUserIdDTO {
 
     private PaymentPage paymentPage;
 
-    public static ResPaymentGetByCustomerDTO of(Page<Payment> paymentPage) {
-        return ResPaymentGetByCustomerDTO.builder()
+    public static ResPaymentGetByUserIdDTO of(Page<Payment> paymentPage) {
+        return ResPaymentGetByUserIdDTO.builder()
                 .paymentPage(new PaymentPage(paymentPage))
                 .build();
     }

--- a/src/main/java/com/sparta/gitandrun/payment/repository/queryDsl/PaymentCustomRepository.java
+++ b/src/main/java/com/sparta/gitandrun/payment/repository/queryDsl/PaymentCustomRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface PaymentCustomRepository {
 
-    Page<Payment> findPaymentsForUserWithConditions(Long userId, ReqPaymentCondDTO condition, Pageable pageable);
+    Page<Payment> findMyPaymentsWithConditions(Long userId, ReqPaymentCondDTO condition, Pageable pageable);
 
     Page<Payment> findCustomerPaymentsWithConditions(ReqPaymentCondByManagerDTO condition, Pageable pageable);
 }

--- a/src/main/java/com/sparta/gitandrun/payment/repository/queryDsl/PaymentCustomRepository.java
+++ b/src/main/java/com/sparta/gitandrun/payment/repository/queryDsl/PaymentCustomRepository.java
@@ -1,5 +1,6 @@
 package com.sparta.gitandrun.payment.repository.queryDsl;
 
+import com.sparta.gitandrun.payment.dto.req.ReqPaymentCondByManagerDTO;
 import com.sparta.gitandrun.payment.dto.req.ReqPaymentCondDTO;
 import com.sparta.gitandrun.payment.entity.Payment;
 import org.springframework.data.domain.Page;
@@ -8,4 +9,6 @@ import org.springframework.data.domain.Pageable;
 public interface PaymentCustomRepository {
 
     Page<Payment> findPaymentsForUserWithConditions(Long userId, ReqPaymentCondDTO condition, Pageable pageable);
+
+    Page<Payment> findCustomerPaymentsWithConditions(ReqPaymentCondByManagerDTO condition, Pageable pageable);
 }

--- a/src/main/java/com/sparta/gitandrun/payment/repository/queryDsl/PaymentCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/gitandrun/payment/repository/queryDsl/PaymentCustomRepositoryImpl.java
@@ -29,9 +29,9 @@ public class PaymentCustomRepositoryImpl implements PaymentCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Payment> findPaymentsForUserWithConditions(Long userId,
-                                                           ReqPaymentCondDTO cond,
-                                                           Pageable pageable) {
+    public Page<Payment> findMyPaymentsWithConditions(Long userId,
+                                                      ReqPaymentCondDTO cond,
+                                                      Pageable pageable) {
 
         List<Payment> results = queryFactory
                 .selectFrom(payment)

--- a/src/main/java/com/sparta/gitandrun/payment/repository/queryDsl/PaymentCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/gitandrun/payment/repository/queryDsl/PaymentCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.gitandrun.payment.dto.req.ReqPaymentCondByManagerDTO;
 import com.sparta.gitandrun.payment.dto.req.ReqPaymentCondDTO;
 import com.sparta.gitandrun.payment.entity.Payment;
 import com.sparta.gitandrun.payment.entity.enums.PaymentStatus;
@@ -59,8 +60,43 @@ public class PaymentCustomRepositoryImpl implements PaymentCustomRepository {
         return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
     }
 
+    @Override
+    public Page<Payment> findCustomerPaymentsWithConditions(ReqPaymentCondByManagerDTO cond,
+                                                            Pageable pageable) {
+
+        List<Payment> results = queryFactory
+                .selectFrom(payment)
+                .join(payment.order, order).fetchJoin()
+                .join(payment.order.store, store).fetchJoin()
+                .where(
+                        deletedEq(cond.getCondition().isDeleted()),
+                        userIdEq(cond.getCustomer().getId()),
+                        statusEq(cond.getCondition().getStatus())
+                )
+                .orderBy(orderSpecifier(cond.getCondition().getSortType()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPQLQuery<Long> countQuery = queryFactory
+                .select(payment.count())
+                .from(payment)
+                .join(payment.order, order).fetchJoin()
+                .join(payment.order.store, store).fetchJoin()
+                .where(
+                        userIdEq(cond.getCustomer().getId()),
+                        statusEq(cond.getCondition().getStatus())
+                );
+
+        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
+    }
+
     private BooleanExpression deletedFalse() {
         return payment.isDeleted.eq(false);
+    }
+
+    private BooleanExpression deletedEq(boolean cond) {
+        return cond ? payment.isDeleted.eq(true) : payment.isDeleted.eq(false);
     }
 
     private BooleanExpression userIdEq(Long userId) {

--- a/src/main/java/com/sparta/gitandrun/payment/repository/queryDsl/PaymentCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/gitandrun/payment/repository/queryDsl/PaymentCustomRepositoryImpl.java
@@ -34,7 +34,7 @@ public class PaymentCustomRepositoryImpl implements PaymentCustomRepository {
 
         List<Payment> results = queryFactory
                 .selectFrom(payment)
-                .join(payment.order).fetchJoin()
+                .join(payment.order, order).fetchJoin()
                 .join(payment.order.store, store).fetchJoin()
                 .where(
                         deletedFalse(),

--- a/src/main/java/com/sparta/gitandrun/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/gitandrun/payment/service/PaymentService.java
@@ -3,15 +3,15 @@ package com.sparta.gitandrun.payment.service;
 import com.sparta.gitandrun.order.dto.res.ResDto;
 import com.sparta.gitandrun.order.entity.Order;
 import com.sparta.gitandrun.order.repository.OrderRepository;
+import com.sparta.gitandrun.payment.dto.req.ReqPaymentCondByManagerDTO;
 import com.sparta.gitandrun.payment.dto.req.ReqPaymentCondDTO;
 import com.sparta.gitandrun.payment.dto.req.ReqPaymentPostDTO;
-import com.sparta.gitandrun.payment.dto.res.ResPaymentGetByCustomerDTO;
+import com.sparta.gitandrun.payment.dto.res.ResPaymentGetByUserIdDTO;
 import com.sparta.gitandrun.payment.entity.Payment;
 import com.sparta.gitandrun.payment.repository.PaymentRepository;
 import com.sparta.gitandrun.user.entity.Role;
 import com.sparta.gitandrun.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j(topic = "Payment-Service")
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
@@ -41,15 +40,33 @@ public class PaymentService {
         고객 결제 목록 조회
     */
     @Transactional(readOnly = true)
-    public ResponseEntity<ResDto<ResPaymentGetByCustomerDTO>> getByCustomer(User user, ReqPaymentCondDTO condition, Pageable pageable) {
+    public ResponseEntity<ResDto<ResPaymentGetByUserIdDTO>> getByCustomer(User user, ReqPaymentCondDTO condition, Pageable pageable) {
 
         Page<Payment> findPaymentPage = paymentRepository.findPaymentsForUserWithConditions(user.getUserId(), condition, pageable);
 
         return new ResponseEntity<>(
-                ResDto.<ResPaymentGetByCustomerDTO>builder()
+                ResDto.<ResPaymentGetByUserIdDTO>builder()
                         .code(HttpStatus.OK.value())
                         .message("결제 목록 조회에 성공했습니다.")
-                        .data(ResPaymentGetByCustomerDTO.of(findPaymentPage))
+                        .data(ResPaymentGetByUserIdDTO.of(findPaymentPage))
+                        .build(),
+                HttpStatus.OK
+        );
+    }
+
+    /*
+        매니저 결제 목록 조회
+    */
+    @Transactional(readOnly = true)
+    public ResponseEntity<ResDto<ResPaymentGetByUserIdDTO>> getByManager(ReqPaymentCondByManagerDTO condition, Pageable pageable) {
+
+        Page<Payment> findPaymentPage = paymentRepository.findCustomerPaymentsWithConditions(condition, pageable);
+
+        return new ResponseEntity<>(
+                ResDto.<ResPaymentGetByUserIdDTO>builder()
+                        .code(HttpStatus.OK.value())
+                        .message("결제 목록 조회에 성공했습니다.")
+                        .data(ResPaymentGetByUserIdDTO.of(findPaymentPage))
                         .build(),
                 HttpStatus.OK
         );

--- a/src/main/java/com/sparta/gitandrun/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/gitandrun/payment/service/PaymentService.java
@@ -42,7 +42,7 @@ public class PaymentService {
     @Transactional(readOnly = true)
     public ResponseEntity<ResDto<ResPaymentGetByUserIdDTO>> getByCustomer(User user, ReqPaymentCondDTO condition, Pageable pageable) {
 
-        Page<Payment> findPaymentPage = paymentRepository.findPaymentsForUserWithConditions(user.getUserId(), condition, pageable);
+        Page<Payment> findPaymentPage = paymentRepository.findMyPaymentsWithConditions(user.getUserId(), condition, pageable);
 
         return new ResponseEntity<>(
                 ResDto.<ResPaymentGetByUserIdDTO>builder()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #90 

## 📝 Description

- `MANAGER` 는 특정 고객의 결제목록을 조회할 수 있도록 하였습니다.
- `isDeleted` 로 논리 삭제 여부에 따른 결제 목록을 조회할 수 있도록 하였습니다.
- 이외 조회 조건은 `CUSTOMER` 와 동일합니다.
       - 상태값 / 정렬에 따른 조회

```java
@Getter
@NoArgsConstructor
public class ReqPaymentCondByManagerDTO {

    @Valid
    @NotNull(message = "고객 정보를 입력해주세요")
    private Customer customer;
    private Condition condition;

    @Getter
    @NoArgsConstructor
    public static class Customer {
        @NotNull(message = "id 를 입력해주세요.")
        private Long id;
    }

    @Getter
    @NoArgsConstructor
    public static class Condition {
        private String status;
        private String sortType;
        private boolean deleted;
    }
}
```
- `MANAGER` 는 요청 `body` 에 고객의 `id` 를 입력하고, `isDeleted` 의 논리 여부를 입력할 수 있습니다.
- `Condition` 은 null 입력해도 `Default` 조건에 의해 조회됩니다.

### deleted = false 기본값으로 조회
![스크린샷 2024-11-17 오전 10 25 28](https://github.com/user-attachments/assets/d9643bdc-763c-422f-9231-5d9b8d9a7feb)

### deleted = true 조회
![스크린샷 2024-11-17 오전 10 26 26](https://github.com/user-attachments/assets/08d06f6c-f90e-49c0-a34b-d2a975ae308b)

## 💬 To Reivewers

- 반환 데이터에 경우에는 `CUSTOMER` 와 차별성을 둘 필요가 없다고  판단해, 동일한 DTO 를 사용하도록 하였습니다.
- `MANAGER` 만이 받았으면 좋겠는 데이터가 있다면 말씀주십시오. 반영하겠습니다.