### PR TITLE
주문 로직 리팩토링 및 보완 코드 작성

### DIFF
--- a/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
@@ -32,9 +32,8 @@ public class OrderController {
     */
     @Secured("ROLE_CUSTOMER")
     @PostMapping
-    public ResponseEntity<ApiResDto> createOrder(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestBody ReqOrderPostDTO dto) {
+    public ResponseEntity<ApiResDto> createOrder(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                 @RequestBody ReqOrderPostDTO dto) {
 
         orderService.createOrder(userDetails.getUser(), dto);
 
@@ -47,11 +46,11 @@ public class OrderController {
    */
     @Secured("ROLE_CUSTOMER")
     @GetMapping("/customer")
-    public ResponseEntity<ResDto<ResOrderGetByCustomerDTO>> getByCustomer(
+    public ResponseEntity<ResDto<ResOrderGetByCustomerDTO>> readByCustomer(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return orderService.getByCustomer(userDetails.getUser(), pageable);
+        return orderService.readByCustomer(userDetails.getUser(), pageable);
     }
 
     /*
@@ -61,20 +60,20 @@ public class OrderController {
 
     @Secured("ROLE_OWNER")
     @GetMapping("/owner")
-    public ResponseEntity<ResDto<ResOrderGetByOwnerDTO>> getByOwner(
+    public ResponseEntity<ResDto<ResOrderGetByOwnerDTO>> readByOwner(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(name = "storeId", required = false) UUID storeId) {
 
-        return orderService.getByOwner(userDetails.getUser(), pageable, storeId);
+        return orderService.readByOwner(userDetails.getUser(), pageable, storeId);
     }
 
     /*
         주문 단일 및 상세 조회
     */
     @GetMapping("/{orderId}")
-    public ResponseEntity<ResDto<ResOrderGetByIdDTO>> getById(@PathVariable("orderId") Long orderId) {
-        return orderService.getBy(orderId);
+    public ResponseEntity<ResDto<ResOrderGetByIdDTO>> readById(@PathVariable("orderId") Long orderId) {
+        return orderService.readById(orderId);
     }
 
     /*

--- a/src/main/java/com/sparta/gitandrun/order/dto/res/ResOrderGetByCustomerDTO.java
+++ b/src/main/java/com/sparta/gitandrun/order/dto/res/ResOrderGetByCustomerDTO.java
@@ -2,6 +2,7 @@ package com.sparta.gitandrun.order.dto.res;
 
 import com.sparta.gitandrun.order.entity.Order;
 import com.sparta.gitandrun.order.entity.OrderMenu;
+import com.sparta.gitandrun.store.entity.Store;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,7 +33,7 @@ public class ResOrderGetByCustomerDTO {
     @Getter
     public static class OrderPage extends PagedModel<OrderPage.OrderDTO> {
 
-        public OrderPage(Page<Order> orderPage, List<OrderMenu> orderMenus) {
+        private OrderPage(Page<Order> orderPage, List<OrderMenu> orderMenus) {
             super(
                     new PageImpl<>(
                             OrderDTO.from(orderPage.getContent(), orderMenus),
@@ -53,15 +54,16 @@ public class ResOrderGetByCustomerDTO {
             private String status;
             private String type;
             private List<OrderMenuDTO> orderMenuDTOS;
+            private StoreDTO storeDTO;
             private int totalPrice;
 
-            public static List<OrderDTO> from(List<Order> orders, List<OrderMenu> orderMenus) {
+            private static List<OrderDTO> from(List<Order> orders, List<OrderMenu> orderMenus) {
                 return orders.stream()
                         .map(order -> from(order, orderMenus))
                         .toList();
             }
 
-            public static OrderDTO from(Order order, List<OrderMenu> orderMenus) {
+            private static OrderDTO from(Order order, List<OrderMenu> orderMenus) {
 
                 List<OrderMenuDTO> orderMenuDTOS = OrderMenuDTO.from(orderMenus).get(order.getId());
 
@@ -71,6 +73,7 @@ public class ResOrderGetByCustomerDTO {
                         .type(order.getOrderType().getType())
                         .orderMenuDTOS(orderMenuDTOS)
                         .totalPrice(sumFrom(orderMenuDTOS))
+                        .storeDTO(StoreDTO.from(order.getStore()))
                         .build();
             }
 
@@ -103,13 +106,30 @@ public class ResOrderGetByCustomerDTO {
                             ));
                 }
 
-                public static OrderMenuDTO from(OrderMenu orderMenu) {
+                private static OrderMenuDTO from(OrderMenu orderMenu) {
                     return OrderMenuDTO.builder()
                             .orderMenuId(orderMenu.getId())
                             .menuId(orderMenu.getMenu().getMenuId())
                             .menuName(orderMenu.getMenu().getMenuName())
                             .menuPrice(orderMenu.getOrderPrice())
                             .count(orderMenu.getOrderCount())
+                            .build();
+                }
+
+
+            }
+
+            @Getter
+            @Builder
+            @NoArgsConstructor
+            @AllArgsConstructor
+            private static class StoreDTO {
+
+                private String name;
+
+                private static StoreDTO from (Store store) {
+                    return StoreDTO.builder()
+                            .name(store.getStoreName())
                             .build();
                 }
             }

--- a/src/main/java/com/sparta/gitandrun/order/dto/res/ResOrderGetByIdDTO.java
+++ b/src/main/java/com/sparta/gitandrun/order/dto/res/ResOrderGetByIdDTO.java
@@ -22,34 +22,14 @@ import java.util.stream.Collectors;
 public class ResOrderGetByIdDTO {
 
     private OrderDTO orderDTO;
-    private StoreDTO storeDTO;
 
-    public static ResOrderGetByIdDTO of(Order order, List<OrderMenu> orderMenus, Store store) {
+    public static ResOrderGetByIdDTO of(Order order, List<OrderMenu> orderMenus) {
         return ResOrderGetByIdDTO.builder()
                 .orderDTO(OrderDTO.from(order, orderMenus))
-                .storeDTO(StoreDTO.from(store))
                 .build();
     }
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    private static class StoreDTO {
-        private UUID storeId;
-        private String zipcode;
-        private String address;
-        private String addressDetail;
 
-        private static StoreDTO from(Store store) {
-            return StoreDTO.builder()
-                    .storeId(store.getStoreId())
-                    .zipcode(store.getAddress().getZipCode())
-                    .address(store.getAddress().getAddress())
-                    .addressDetail(store.getAddress().getAddressDetail())
-                    .build();
-        }
-    }
 
     @Getter
     @Builder
@@ -62,8 +42,9 @@ public class ResOrderGetByIdDTO {
         private LocalDateTime createdAt;
         private List<OrderMenuDTO> orderMenuDTOS;
         private int totalPrice;
+        private StoreDTO storeDTO;
 
-        public static OrderDTO from(Order order, List<OrderMenu> orderMenus) {
+        private static OrderDTO from(Order order, List<OrderMenu> orderMenus) {
 
             List<OrderMenuDTO> orderMenuDTOS = OrderMenuDTO.from(orderMenus).get(order.getId());
 
@@ -74,6 +55,7 @@ public class ResOrderGetByIdDTO {
                     .createdAt(order.getCreatedAt())
                     .orderMenuDTOS(orderMenuDTOS)
                     .totalPrice(sumFrom(orderMenuDTOS))
+                    .storeDTO(OrderDTO.StoreDTO.from(order.getStore()))
                     .build();
         }
 
@@ -87,7 +69,7 @@ public class ResOrderGetByIdDTO {
         @Builder
         @NoArgsConstructor
         @AllArgsConstructor
-        public static class OrderMenuDTO {
+        private static class OrderMenuDTO {
 
             private Long orderMenuId;
             private UUID menuId;
@@ -106,13 +88,33 @@ public class ResOrderGetByIdDTO {
                         ));
             }
 
-            public static OrderMenuDTO from(OrderMenu orderMenu) {
+            private static OrderMenuDTO from(OrderMenu orderMenu) {
                 return OrderMenuDTO.builder()
                         .orderMenuId(orderMenu.getId())
                         .menuId(orderMenu.getMenu().getMenuId())
                         .menuName(orderMenu.getMenu().getMenuName())
                         .menuPrice(orderMenu.getOrderPrice())
                         .count(orderMenu.getOrderCount())
+                        .build();
+            }
+        }
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        private static class StoreDTO {
+            private UUID storeId;
+            private String zipcode;
+            private String address;
+            private String addressDetail;
+
+            private static StoreDTO from(Store store) {
+                return StoreDTO.builder()
+                        .storeId(store.getStoreId())
+                        .zipcode(store.getAddress().getZipCode())
+                        .address(store.getAddress().getAddress())
+                        .addressDetail(store.getAddress().getAddressDetail())
                         .build();
             }
         }

--- a/src/main/java/com/sparta/gitandrun/order/entity/Order.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/Order.java
@@ -40,7 +40,7 @@ public class Order extends BaseEntity {
     @JoinColumn(name = "p_user_id")
     private User user;
 
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "p_store_id")
     private Store store;
 

--- a/src/main/java/com/sparta/gitandrun/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/gitandrun/order/repository/OrderRepository.java
@@ -28,5 +28,5 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             "and o.isDeleted = false ")
     Page<Order> findByIdInAndIsDeletedFalse(@Param("orderIds") List<Long> orderIds, Pageable pageable);
 
-
+    Optional<Order> findByIdAndStore_User_UserId(Long orderId, Long userId);
 }

--- a/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
+++ b/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
@@ -119,13 +119,11 @@ public class OrderService {
 
         List<OrderMenu> findOrderMenus = orderMenuRepository.findByOrderId(orderId);
 
-        Store store = findOrderMenus.get(0).getMenu().getStore();
-
         return new ResponseEntity<>(
                 ResDto.<ResOrderGetByIdDTO>builder()
                         .code(HttpStatus.OK.value())
                         .message("주문 조회에 성공했습니다.")
-                        .data(ResOrderGetByIdDTO.of(findOrder, findOrderMenus, store))
+                        .data(ResOrderGetByIdDTO.of(findOrder, findOrderMenus))
                         .build(),
                 HttpStatus.OK
         );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #94 

## 📝 Description

- 주문 조회 간 응답 DTO 의 구조를 변경하였습니다.
- 응답 간 주문 대상 가게의 이름을 명시하도록 하였습니다.
- 메서드 명을 일관성있게 재구성하였습니다.
- 주문 거절 로직의 구조를 변경하였습니다.

### 기존 방식 :
1. `Owner` 권한 `User` 본인의 `Store `리스트를 조회한다.
2. 요청 `Order Id` 를 통해 거절하고자 하는 `Order` 의 `OrderMenu` 리스트를 조회
3. 해당 `OrderMenu` 리스트의 첫 번째 인덱스 값을 불러와 `Menu` 를 조회하고, 이어서 `Store` 를 조회한다.
4. 해당 `Store` 가 **"1번"** 항목에서 조회한 가게리스트에 존재하는지 여부를 판단하고, 포함되지 않는다면 권한 없음으로 처리

### 개선 방식 :
1. 현재 인증된 유저의 id 와 요청 파라미터로 전달 받은 `Order id` 를 통해 `Order` 를 조회한다.
2. 해당 `Order` 의 `Store` 의 `User Id` 와, 현재 인증된 `User Id` 와 일치하면 `Order` 를 조회한다.
3. `Null` 이면 권한 없음 처리


## 💬 To Reivewers

- 보완점이 있다면 알려주십시오.