### PR TITLE
리뷰와 가게 맵핑

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ AI를 통해 AI가 생성한 자연스러운 메뉴 설명으로 고객에게 �
 
 ---
 
+---
+
 ## 💻 개발 환경
 
 ![example workflow](https://github.com/jabberwocker04/gitandrun/actions/workflows/gradle.yml/badge.svg)

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -97,7 +97,7 @@ public class ReviewController {
         return new ApiResDto("리뷰 조회 성공", 200, reviews);
     }
 
-    //리뷰 수정 - 완료
+    //리뷰 수정
     @PatchMapping("/{reviewId}")
     public ResponseEntity<ApiResDto> updateReview(
             @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -32,7 +32,7 @@ public class ReviewController {
 
     //리뷰 작성
     @Secured({"ROLE_CUSTOMER", "ROLE_OWNER"})
-    @PostMapping("/write/{orderId}")
+    @PostMapping("/{orderId}")
     public ResponseEntity<ApiResDto> createReview(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody ReviewRequestDto requestDto,

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -81,15 +81,19 @@ public class ReviewController {
         return ResponseEntity.ok().body(new ApiResDto("본인 리뷰 조회 성공", HttpStatus.OK.value(), reviews));
     }
 
-    // 관리자 - 모든 리뷰 검색 (키워드)
+    // 관리자 - 모든 리뷰 검색 (reviewContent, userId, reviewId, storeId)
     @Secured({"ROLE_MANAGER", "ROLE_ADMIN"})
     @GetMapping("/admin")
-    public ApiResDto getReviewsByKeyword(
-            @RequestParam(required = false) String keyword,
+    public ApiResDto getReviewsByFilters(
+            @RequestParam(required = false) String keyword,    // 키워드 검색
+            @RequestParam(required = false) Long userId,      // userId로 검색
+            @RequestParam(required = false) UUID reviewId,    // reviewId로 검색
+            @RequestParam(required = false) UUID storeId,     // storeId로 검색
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "createdAt") String sortBy) {
-        Page<AdminReviewResponseDto> reviews = reviewService.searchReviewsWithKeyword(keyword, page, size, sortBy);
+        Page<AdminReviewResponseDto> reviews = reviewService.searchReviewsWithFilters(
+                keyword, userId, reviewId, storeId, page, size, sortBy);
         return new ApiResDto("리뷰 조회 성공", 200, reviews);
     }
 

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -70,7 +70,7 @@ public class ReviewController {
 
     // CUSTOEMR, OWNER - 본인이 작성한 리뷰 조회
     @Secured({"ROLE_CUSTOMER", "ROLE_OWNER"})
-    @GetMapping("/user/myreviews")
+    @GetMapping("/myReviews")
     public ResponseEntity<ApiResDto> getMyReviewsByUserId(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam(defaultValue="0") int page,
@@ -107,7 +107,7 @@ public class ReviewController {
         return ResponseEntity.ok().body(new ApiResDto("리뷰 수정 완료", HttpStatus.OK.value()));
     }
 
-    //리뷰 삭제 - 완료
+    //리뷰 삭제
     @DeleteMapping("{reviewId}")
     public ResponseEntity<ApiResDto> deleteReview(
             @PathVariable UUID reviewId,

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -6,6 +6,7 @@ import com.sparta.gitandrun.review.dto.ReviewRequestDto;
 import com.sparta.gitandrun.review.dto.UserReviewResponseDto;
 import com.sparta.gitandrun.review.service.ReviewService;
 import com.sparta.gitandrun.user.security.UserDetailsImpl;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -35,7 +36,7 @@ public class ReviewController {
     @PostMapping("/{orderId}")
     public ResponseEntity<ApiResDto> createReview(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestBody ReviewRequestDto requestDto,
+            @RequestBody @Valid ReviewRequestDto requestDto,
             @PathVariable Long orderId) {
         Long userId = userDetails.getUser().getUserId();
         reviewService.createReview(requestDto, userId, orderId);
@@ -102,7 +103,7 @@ public class ReviewController {
     public ResponseEntity<ApiResDto> updateReview(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable UUID reviewId,
-            @RequestBody ReviewRequestDto requestDto) {
+            @RequestBody @Valid ReviewRequestDto requestDto) {
         reviewService.updateReview(reviewId, userDetails, requestDto);
         return ResponseEntity.ok().body(new ApiResDto("리뷰 수정 완료", HttpStatus.OK.value()));
     }

--- a/src/main/java/com/sparta/gitandrun/review/dto/AdminReviewResponseDto.java
+++ b/src/main/java/com/sparta/gitandrun/review/dto/AdminReviewResponseDto.java
@@ -28,7 +28,7 @@ public class AdminReviewResponseDto {
         this.reviewId = review.getReviewId();
         this.userId = review.getUser().getUserId();
         this.orderId = review.getOrder().getId();
-        this.storeId = review.getStoreId();
+        this.storeId = review.getStore().getStoreId();
         this.reviewContent = review.getReviewContent();
         this.reviewRating = review.getReviewRating();
         this.createdBy = review.getCreatedBy();

--- a/src/main/java/com/sparta/gitandrun/review/entity/Review.java
+++ b/src/main/java/com/sparta/gitandrun/review/entity/Review.java
@@ -55,5 +55,6 @@ public class Review extends BaseEntity {
         this.order = order;
         this.reviewContent = requestDto.getReviewContent();
         this.reviewRating = requestDto.getReviewRating();
+        initAuditInfo(user);
     }
 }

--- a/src/main/java/com/sparta/gitandrun/review/entity/Review.java
+++ b/src/main/java/com/sparta/gitandrun/review/entity/Review.java
@@ -3,6 +3,7 @@ package com.sparta.gitandrun.review.entity;
 import com.sparta.gitandrun.common.entity.BaseEntity;
 import com.sparta.gitandrun.review.dto.ReviewRequestDto;
 import com.sparta.gitandrun.order.entity.Order;
+import com.sparta.gitandrun.store.entity.Store;
 import com.sparta.gitandrun.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -33,8 +34,9 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user; //회원별 조회
 
-    @Column(name = "store_id", nullable = false)
-    private UUID storeId; //가게별 조회
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store; //가게별 조회
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id", nullable = false, unique = true)
@@ -49,9 +51,9 @@ public class Review extends BaseEntity {
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 
-    public Review(ReviewRequestDto requestDto, User user, UUID storeId, Order order) {
+    public Review(ReviewRequestDto requestDto, User user, Store store, Order order) {
         this.user = user;
-        this.storeId = storeId;
+        this.store = store;
         this.order = order;
         this.reviewContent = requestDto.getReviewContent();
         this.reviewRating = requestDto.getReviewRating();

--- a/src/main/java/com/sparta/gitandrun/review/exception/ReviewException.java
+++ b/src/main/java/com/sparta/gitandrun/review/exception/ReviewException.java
@@ -1,0 +1,30 @@
+package com.sparta.gitandrun.review.exception;
+
+import com.sparta.gitandrun.common.entity.ApiResDto;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ReviewException {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResDto> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        // 오류 메시지 추출
+        List<String> errors = ex.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.toList());
+
+        // ApiResDto 응답 객체 생성
+        ApiResDto response = new ApiResDto("유효성 검사 오류", 400, errors);
+
+        return ResponseEntity.badRequest().body(response);
+    }
+
+}

--- a/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
@@ -26,10 +26,14 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     Page<Review> findByStoreId(@Param("storeId") UUID storeId, Pageable pageable);
 
     @Query("SELECT r FROM Review r " +
-            "WHERE (:keyword IS NULL OR " +
-            "LOWER(r.reviewContent) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
-            "CONCAT(r.reviewId, '') LIKE CONCAT('%', :keyword, '%') OR " +
-            "CONCAT(r.user.userId, '') LIKE CONCAT('%', :keyword, '%') OR " +
-            "CONCAT(r.store.storeId, '') LIKE CONCAT('%', :keyword, '%'))")
-    Page<Review> searchReviewsWithKeyword(@Param("keyword") String keyword, Pageable pageable);
+            "WHERE (:keyword IS NULL OR LOWER(r.reviewContent) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+            "AND (:userId IS NULL OR r.user.userId = :userId) " +
+            "AND (:reviewId IS NULL OR r.reviewId = :reviewId) " +
+            "AND (:storeId IS NULL OR r.store.storeId = :storeId)")
+    Page<Review> searchReviewsWithFilters(
+            @Param("keyword") String keyword,
+            @Param("userId") Long userId,
+            @Param("reviewId") UUID reviewId,
+            @Param("storeId") UUID storeId,
+            Pageable pageable);
 }

--- a/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
@@ -1,6 +1,5 @@
 package com.sparta.gitandrun.review.repository;
 
-import com.sparta.gitandrun.order.entity.Order;
 import com.sparta.gitandrun.review.entity.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
     // 해당 주문에 리뷰가 이미 존재하는지 확인
-    boolean existsByOrder(Order order);
+    boolean existsByOrderId(Long orderId);
 
     // CUSTOMER, OWNER: 본인이 작성한 리뷰 조회
     @Query("SELECT r FROM Review r WHERE r.user.userId = :userId AND r.isDeleted = false")

--- a/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.sparta.gitandrun.review.repository;
 
+import com.sparta.gitandrun.order.entity.Order;
 import com.sparta.gitandrun.review.entity.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,18 +12,18 @@ import org.springframework.data.repository.query.Param;
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
     // 해당 주문에 리뷰가 이미 존재하는지 확인
-    boolean existsByOrderId(Long orderId);
+    boolean existsByOrder(Order order);
 
     // CUSTOMER, OWNER: 본인이 작성한 리뷰 조회
     @Query("SELECT r FROM Review r WHERE r.user.userId = :userId AND r.isDeleted = false")
     Page<Review> findByUserId(@Param("userId") Long userId, Pageable pageable);
 
     // OWNER: 본인 가게의 사용자의 리뷰를 조회
-    @Query("SELECT r FROM Review r WHERE r.storeId = :storeId AND r.user.userId = :userId AND r.isDeleted = false")
+    @Query("SELECT r FROM Review r WHERE r.store.storeId = :storeId AND r.user.userId = :userId AND r.isDeleted = false")
     Page<Review> findByStoreIdAndUserId(UUID storeId, Long userId, Pageable pageable);
 
     // CUSTOMER: 특정 가게의 리뷰를 조회
-    @Query("SELECT r FROM Review r WHERE r.storeId = :storeId AND r.isDeleted = false")
+    @Query("SELECT r FROM Review r WHERE r.store.storeId = :storeId AND r.isDeleted = false")
     Page<Review> findByStoreId(@Param("storeId") UUID storeId, Pageable pageable);
 
     @Query("SELECT r FROM Review r " +
@@ -30,6 +31,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
             "LOWER(r.reviewContent) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
             "CONCAT(r.reviewId, '') LIKE CONCAT('%', :keyword, '%') OR " +
             "CONCAT(r.user.userId, '') LIKE CONCAT('%', :keyword, '%') OR " +
-            "CONCAT(r.storeId, '') LIKE CONCAT('%', :keyword, '%'))")
+            "CONCAT(r.store.storeId, '') LIKE CONCAT('%', :keyword, '%'))")
     Page<Review> searchReviewsWithKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -37,12 +37,19 @@ public class ReviewService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
 
-        // 2. 주문 소유 및 상태 확인
-        validateOrder(order, userId);
+        // 2. 주문 소유 확인
+        if (!order.getUser().getUserId().equals(userId)) {
+            throw new IllegalArgumentException("본인의 리뷰만 작성이 가능합니다.");
+        }
 
-        // 3. 중복 리뷰 확인
-        if (reviewRepository.existsByOrder(order)) {
-            throw new IllegalStateException("이미 리뷰가 작성된 주문입니다.");
+        // 3. 주문 상태 확인
+        if (order.getOrderStatus() != OrderStatus.COMPLETED) {
+            throw new IllegalArgumentException("완료된 주문만 리뷰 작성이 가능합니다.");
+        }
+
+        // 4. 중복 리뷰 확인
+        if (reviewRepository.existsByOrderId(orderId)) {
+            throw new IllegalArgumentException("이미 리뷰가 작성된 주문입니다.");
         }
 
         Review review = new Review(requestDto, order.getUser(), order.getStore(), order);
@@ -134,19 +141,6 @@ public class ReviewService {
     private Review getReview(UUID reviewId) {
         return reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
-    }
-
-    // 주문 존재 여부 및 본인 주문 확인
-    private void validateOrder(Order order, Long userId) {
-        // 주문 소유자 확인
-        if (!order.getUser().getUserId().equals(userId)) {
-            throw new SecurityException("해당 주문에 대한 권한이 없습니다.");
-        }
-
-        // 주문 상태 확인
-        if (order.getOrderStatus() != OrderStatus.COMPLETED) {
-            throw new IllegalArgumentException("리뷰를 작성할 수 있는 상태의 주문이 아닙니다.");
-        }
     }
 
     // 리뷰가 비어있는지 확인

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -56,7 +56,7 @@ public class ReviewService {
         reviewRepository.save(review);
     }
 
-    // OWNER: 본인 가게 리뷰 조회
+    // OWNER: 본인 가게 리뷰만 조회
     @Transactional(readOnly = true)
     public Page<UserReviewResponseDto> getOwnerReviewsByStore(Long userId, UUID storeId, int page, int size, String sortBy) {
         List<Store> stores = storeRepository.findByUser_UserId(userId);
@@ -72,7 +72,7 @@ public class ReviewService {
         return reviews.map(UserReviewResponseDto::new);
     }
 
-    // CUSTOMER: 모든 가게 리뷰 조회
+    // 모든 가게 리뷰 조회 (OWNER 제외)
     @Transactional(readOnly = true)
     public Page<UserReviewResponseDto> getCustomerReviewsByStore(UUID storeId, int page, int size, String sortBy) {
         Pageable pageable = pageable(page, size, sortBy, false);
@@ -131,6 +131,7 @@ public class ReviewService {
         if (requestDto.getReviewRating() != null) {
             review.setReviewRating(requestDto.getReviewRating());
         }
+        review.setUpdatedBy(userDetails.getUser().getUsername());
     }
 
     //리뷰 삭제

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -90,20 +90,28 @@ public class ReviewService {
         return reviews.map(UserReviewResponseDto::new);
     }
 
-    // 관리자 - 모든 리뷰 검색 (키워드)
+    // 관리자 - 모든 리뷰 검색 (reviewContent, userId, reviewId, storeId)
     @Transactional(readOnly = true)
-    public Page<AdminReviewResponseDto> searchReviewsWithKeyword(
-            String keyword, int page, int size, String sortBy) {
-            Pageable pageable = pageable(page, size, sortBy, true);
+    public Page<AdminReviewResponseDto> searchReviewsWithFilters(
+            String keyword, Long userId, UUID reviewId, UUID storeId, int page, int size, String sortBy) {
+        Pageable pageable = pageable(page, size, sortBy, true);
 
-        // keyword가 null이거나 공백인 경우 전체 조회
-        if (keyword == null || keyword.trim().isEmpty()) {
+        // 필터 조건이 모두 비어 있는지 확인
+        boolean isEmptyFilter = (keyword == null || keyword.trim().isEmpty())
+                && userId == null
+                && reviewId == null
+                && storeId == null;
+
+        // 필터 조건이 모두 비어 있으면 전체 리뷰 조회
+        if (isEmptyFilter) {
             Page<Review> allReviews = reviewRepository.findAll(pageable);
             reviewEmpty(allReviews);
             return allReviews.map(AdminReviewResponseDto::new);
         }
 
-        Page<Review> reviews = reviewRepository.searchReviewsWithKeyword(keyword, pageable);
+        // 필터 조건이 있을 경우 필터링해서 조회
+        Page<Review> reviews = reviewRepository.searchReviewsWithFilters(
+                keyword, userId, reviewId, storeId, pageable);
         reviewEmpty(reviews);
         return reviews.map(AdminReviewResponseDto::new);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #98 

## 📝 Description

- 리뷰와 가게를 다대일 맵핑했습니다.
- 일부 엔드포인트 수정했습니다.
- 리뷰 작성 시 createdBy, updatedBy가 null로 나오는 오류 수정했습니다.
- 정렬 필터를 추가했습니다.
    - 최근 생성순: 'createdAt' (기본)
    - 오래된 순: 'createdAt:asc'
    - 별점 높은 순: 'reviewRating:desc'
    - 별점 낮은 순: 'reviewRating:asc'
    - 업데이트 순: 'updatedAt' (관리자용)
- 관리자 리뷰 검색에서 userId, storeId, reviewId, reviewContent를 
   requestParam으로 받아 각각 검색하는 걸로 수정했습니다.

## 💬 To Reivewers
