### PR TITLE
주문 및 결제 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/gitandrun/order/controller/OrderController.java
@@ -102,4 +102,18 @@ public class OrderController {
 
         return ResponseEntity.ok().body(new ApiResDto("주문 거절 완료", HttpStatus.OK.value()));
     }
+
+    /*
+        주문 삭제
+        - 어드민은 주문을 삭제할 수 있다.
+    */
+    @Secured("ROLE_ADMIN")
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<ApiResDto> deleteOrder(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                 @PathVariable("orderId") Long orderId) {
+
+        orderService.deleteOrder(userDetails.getUser(), orderId);
+
+        return ResponseEntity.ok().body(new ApiResDto("주문 삭제 완료", HttpStatus.OK.value()));
+    }
 }

--- a/src/main/java/com/sparta/gitandrun/order/entity/Order.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/Order.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -84,11 +85,12 @@ public class Order extends BaseEntity {
     }
 
     // == 주문 거절 메서드 == //
-    public void rejectOrder() {
+    public void rejectOrder(User user) {
         if (!Objects.equals(this.getOrderStatus().status, OrderStatus.PENDING.status)) {
             throw new IllegalArgumentException("해당 주문은 이미 취소, 완료 또는 거절된 상태입니다.");
         }
         this.orderStatus = OrderStatus.REJECT;
+        this.setUpdatedBy(user.getUsername());
     }
 
     // == 주문상태 변경 메서드 == //
@@ -100,5 +102,11 @@ public class Order extends BaseEntity {
     // == 조회 메서드 == //
     public int getTotalPrice() {
         return orderMenus.stream().mapToInt(OrderMenu::getOrderPrice).sum();
+    }
+
+    public void deleteOrder(User user) {
+        this.isDeleted = false;
+        this.setDeletedAt(LocalDateTime.now());
+        this.setDeletedBy(user.getUsername());
     }
 }

--- a/src/main/java/com/sparta/gitandrun/order/entity/Order.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/Order.java
@@ -107,6 +107,7 @@ public class Order extends BaseEntity {
     public void deleteOrder(User user) {
         this.isDeleted = true;
         this.setDeletedAt(LocalDateTime.now());
+        this.setUpdatedBy(user.getUsername());
         this.setDeletedBy(user.getUsername());
     }
 }

--- a/src/main/java/com/sparta/gitandrun/order/entity/Order.java
+++ b/src/main/java/com/sparta/gitandrun/order/entity/Order.java
@@ -105,7 +105,7 @@ public class Order extends BaseEntity {
     }
 
     public void deleteOrder(User user) {
-        this.isDeleted = false;
+        this.isDeleted = true;
         this.setDeletedAt(LocalDateTime.now());
         this.setDeletedBy(user.getUsername());
     }

--- a/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
+++ b/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
@@ -154,10 +154,7 @@ public class OrderService {
     // 주문 삭제
     @Transactional
     public void deleteOrder(User user, Long orderId) {
-
-        Order findOrder = getOrderById(orderId);
-
-        findOrder.deleteOrder(user);
+        getOrderById(orderId).deleteOrder(user);
     }
 
     /*

--- a/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
+++ b/src/main/java/com/sparta/gitandrun/order/service/OrderService.java
@@ -147,7 +147,17 @@ public class OrderService {
                 ? getOrderByIdAndOwner(user, orderId)
                 : getOrderById(orderId);
 
-        order.rejectOrder();
+        order.rejectOrder(user);
+    }
+
+
+    // 주문 삭제
+    @Transactional
+    public void deleteOrder(User user, Long orderId) {
+
+        Order findOrder = getOrderById(orderId);
+
+        findOrder.deleteOrder(user);
     }
 
     /*

--- a/src/main/java/com/sparta/gitandrun/payment/contoller/PaymentController.java
+++ b/src/main/java/com/sparta/gitandrun/payment/contoller/PaymentController.java
@@ -70,4 +70,14 @@ public class PaymentController {
 
         return ResponseEntity.ok().body(new ApiResDto("취소 성공", HttpStatus.OK.value()));
     }
+
+    @Secured("ROLE_ADMIN")
+    @DeleteMapping("/{paymentId}")
+    public ResponseEntity<ApiResDto> deletePayment(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                   @PathVariable("paymentId")Long paymentId) {
+
+        paymentService.deletePayment(userDetails.getUser(), paymentId);
+
+        return ResponseEntity.ok().body(new ApiResDto("취소 성공", HttpStatus.OK.value()));
+    }
 }

--- a/src/main/java/com/sparta/gitandrun/payment/entity/Payment.java
+++ b/src/main/java/com/sparta/gitandrun/payment/entity/Payment.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
@@ -75,6 +77,13 @@ public class Payment extends BaseEntity {
     public void cancelPayment(User user) {
         this.paymentStatus = PaymentStatus.CANCEL;
         this.order.cancelOrder();
-        setUpdatedBy(user.getUsername());
+        this.setUpdatedBy(user.getUsername());
+    }
+
+    public void deletePayment(User user) {
+        this.isDeleted = true;
+        this.setDeletedAt(LocalDateTime.now());
+        this.setUpdatedBy(user.getUsername());
+        this.setDeletedBy(user.getUsername());
     }
 }

--- a/src/main/java/com/sparta/gitandrun/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/gitandrun/payment/service/PaymentService.java
@@ -110,6 +110,12 @@ public class PaymentService {
         payment.cancelPayment(user);
     }
 
+    @Transactional
+    public void deletePayment(User user, Long paymentId) {
+        getPayment(paymentId).deletePayment(user);
+    }
+
+
     private Payment getPaymentBy(Long paymentId) {
         return paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 항목입니다."));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #106 

## 📝 Description

- `ADMIN` 권한의 유저가 주문 및 결제를 삭제합니다.

```java
@Secured("ROLE_ADMIN")
@DeleteMapping("/{orderId}")
public ResponseEntity<ApiResDto> deleteOrder(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                 @PathVariable("orderId") Long orderId) {

        orderService.deleteOrder(userDetails.getUser(), orderId);

        return ResponseEntity.ok().body(new ApiResDto("주문 삭제 완료", HttpStatus.OK.value()));
    }

...

@Transactional
public void deleteOrder(User user, Long orderId) {
        getOrderById(orderId).deleteOrder(user);
    }

...

public void deleteOrder(User user) {
        this.isDeleted = true;
        this.setDeletedAt(LocalDateTime.now());
        this.setUpdatedBy(user.getUsername());
        this.setDeletedBy(user.getUsername());
    }
```
- 주문 삭제 코드입니다.
- 결제 삭제도 이와 동일한 구조입니다.
- @Secured("ROLE_ADMIN") 를 통해 권한을 검증합니다.
- 논리 삭제로 처리하였습니다.