### PR TITLE
메뉴 Entity 길이와 isDeleted 여부에 따른 검색 내용 수정

### DIFF
--- a/src/main/java/com/sparta/gitandrun/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/gitandrun/menu/controller/MenuController.java
@@ -12,7 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -59,7 +58,7 @@ public class MenuController {
     }
 
       //READ
-      //StoreId에 해당하는 모든 메뉴에 대한 필드 조회
+      //StoreId에 해당하는 모든 메뉴에 대한 필드 조회 ( not Deleted)
       @Secured({"ROLE_OWNER","ROLE_MANAGER","ROLE_ADMIN"})
       @GetMapping("/search/{storeId}")
       public ResponseEntity<ApiResDto> getDetailMenu(
@@ -70,6 +69,19 @@ public class MenuController {
           Page<MenuResponseDto> DetailMenus = menuService.getDetailMenu(storeId, sortBy, page, size);
           return ResponseEntity.ok().body(new ApiResDto("가게에 대한 구체적인 메뉴 검색 완료", HttpStatus.OK.value(), DetailMenus));
       }
+
+    //READ
+    //StoreId에 해당하는 모든 삭제된 메뉴에 대한 필드 조회 (Deleted)
+    @Secured({"ROLE_OWNER","ROLE_MANAGER","ROLE_ADMIN"})
+    @GetMapping("/search/deleted/{storeId}")
+    public ResponseEntity<ApiResDto> getDetailDeletedMenu(
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @PathVariable UUID storeId){
+        Page<MenuResponseDto> DetailMenus = menuService.getDetailDeletedMenu(storeId, sortBy, page, size);
+        return ResponseEntity.ok().body(new ApiResDto("가게에서 삭제된 메뉴 검색 완료", HttpStatus.OK.value(), DetailMenus));
+    }
 
     //READ
     //가게 이름에 메뉴명이 들어가는 가게 검색 및 가게의 메뉴를 모두 조회

--- a/src/main/java/com/sparta/gitandrun/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/gitandrun/menu/controller/MenuController.java
@@ -43,7 +43,7 @@ public class MenuController {
     @DeleteMapping("/{menuId}")
     public ResponseEntity<ApiResDto> deleteMenu(@PathVariable("menuId") UUID menuId){
         menuService.deleteMenu(menuId);
-        return ResponseEntity.ok().body(new ApiResDto("삭제 완료", HttpStatus.OK.value()));
+        return ResponseEntity.ok().body(new ApiResDto("메뉴 삭제 완료", HttpStatus.OK.value()));
     }
 
     //READ
@@ -77,15 +77,15 @@ public class MenuController {
     public ResponseEntity<ApiResDto> getStoreAndMenus(
             @RequestParam String storeName,
             @RequestParam(defaultValue = "createdAt") String sortBy,
-            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-        Page<StoreWithMenusDto> StoreAndMenu = menuService.getStoreAndMenus(storeName, sortBy, page-1, size);
+        Page<StoreWithMenusDto> StoreAndMenu = menuService.getStoreAndMenus(storeName, sortBy, page, size);
         return ResponseEntity.ok().body(new ApiResDto("메뉴명으로 가게 검색 완료", HttpStatus.OK.value(), StoreAndMenu));
     }
 
     //READ ony One
     @GetMapping("/{menuid}")
-    @Secured({"ROLE_MANAGER","ROLE_ADMIN"})
+    @Secured({"ROLE_MANAGER","ROLE_ADMIN", "ROLE_OWNER"})
     public MenuResponseDto getOneMenu(@PathVariable("menuid") UUID menuId){
         return menuService.getOneMenu(menuId);
     }

--- a/src/main/java/com/sparta/gitandrun/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/gitandrun/menu/controller/MenuController.java
@@ -54,7 +54,7 @@ public class MenuController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size){
         Page<MenuResponseDto> AllMenuPage = menuService.getAllMenus(sortBy, page, size);
-        return ResponseEntity.ok().body(new ApiResDto("가게에 대한 구체적인 메뉴 검색 완료", HttpStatus.OK.value(), AllMenuPage));
+        return ResponseEntity.ok().body(new ApiResDto("메뉴에 대한 구체적인 정보 검색 완료", HttpStatus.OK.value(), AllMenuPage));
     }
 
       //READ

--- a/src/main/java/com/sparta/gitandrun/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/gitandrun/menu/entity/Menu.java
@@ -35,24 +35,24 @@ public class Menu extends BaseEntity {
     @Column(name = "menuContent", nullable = false, length = 100)
     private String menuContent;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false)
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     private String createdBy;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false)
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     private String updatedBy;
 
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
 
-    @Column(nullable = true, length = 100)
+    @Column(nullable = true)
     private LocalDateTime deletedAt;
 
     @Column(nullable = true, length = 100)

--- a/src/main/java/com/sparta/gitandrun/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/gitandrun/menu/repository/MenuRepository.java
@@ -18,8 +18,11 @@ public interface MenuRepository extends JpaRepository<Menu, UUID> {
 
     Page<Menu> findAll(Pageable pageable);
 
-    @Query("select m from Menu m where m.store.storeId =:storeId")
+    @Query("select m from Menu m where m.store.storeId =:storeId AND m.isDeleted AND m.isDeleted = false ")
     Page<Menu> findAllByStoreId(@Param("storeId") UUID storeId, Pageable pageable);
+
+    @Query("select m from Menu m where m.store.storeId =:storeId AND m.isDeleted AND m.isDeleted = true ")
+    Page<Menu> findAllByStoreIdDeleted(@Param("storeId") UUID storeId, Pageable pageable);
 
     @Query("SELECT m FROM Menu m JOIN m.store s WHERE s.isDeleted = false AND m.isDeleted = false AND s.storeName LIKE %:storeName%")
     Page<Menu> findMenusByStoreName(@Param("storeName") String storeName, Pageable pageable);

--- a/src/main/java/com/sparta/gitandrun/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/gitandrun/menu/repository/MenuRepository.java
@@ -21,6 +21,6 @@ public interface MenuRepository extends JpaRepository<Menu, UUID> {
     @Query("select m from Menu m where m.store.storeId =:storeId")
     Page<Menu> findAllByStoreId(@Param("storeId") UUID storeId, Pageable pageable);
 
-    @Query("SELECT m FROM Menu m JOIN m.store s WHERE s.storeName LIKE %:storeName%")
+    @Query("SELECT m FROM Menu m JOIN m.store s WHERE s.isDeleted = false AND m.isDeleted = false AND s.storeName LIKE %:storeName%")
     Page<Menu> findMenusByStoreName(@Param("storeName") String storeName, Pageable pageable);
 }

--- a/src/main/java/com/sparta/gitandrun/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/gitandrun/menu/service/MenuService.java
@@ -76,7 +76,7 @@ public class MenuService {
         return menuList.map(menu -> new MenuResponseDto(menu));
     }
 
-    //하나의 가게에 있 모든 메뉴 검색
+    //하나의 가게에 있는 모든 메뉴 검색
     @Transactional(readOnly = true)
     public Page<MenuResponseDto> getDetailMenu(UUID storeId, String sortBy, int page, int size) {
         int realSize = ConfirmPageSize(size);

--- a/src/main/java/com/sparta/gitandrun/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/gitandrun/menu/service/MenuService.java
@@ -87,6 +87,17 @@ public class MenuService {
         return menuList.map(menu -> new MenuResponseDto(menu));
     }
 
+    //하나의 가게에 있는 모든 삭제된 메뉴 검색
+    @Transactional(readOnly = true)
+    public Page<MenuResponseDto> getDetailDeletedMenu(UUID storeId, String sortBy, int page, int size) {
+        int realSize = ConfirmPageSize(size);
+        findStoreId(storeId);
+        Pageable pageable = PageRequest.of(page, realSize, Sort.by(sortBy).ascending());
+        Page<Menu> menuList = menuRepository.findAllByStoreIdDeleted(storeId, pageable);
+
+        return menuList.map(menu -> new MenuResponseDto(menu));
+    }
+
     //메뉴를 검색시 가게와 가게의 메뉴이름, 메뉴내용 검색
     @Transactional(readOnly = true)
     public Page<StoreWithMenusDto> getStoreAndMenus(String storeName, String sortBy, int page, int size) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #110 

## 📝 Description

#### Menu의 is_Deleted=True로 설정된 부분을 보이지 않게 변경하였습니다.
- ![image](https://github.com/user-attachments/assets/10df4f2f-58f7-404d-87ed-8dccf581d594)
- ![image](https://github.com/user-attachments/assets/d78b296c-71fa-44a6-9850-bb546829427f)

####
Menu Entity에서
{created, updated, deleted}By의 Entity Length를 수정하였습니다 ( 요구사항 length=100 )

## 💬 To Reivewers

