### PR TITLE
관리자 기능 추가(리뷰 복구, 리뷰 조회 시 삭제여부 선택)

### DIFF
--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -109,12 +109,22 @@ public class ReviewController {
     }
 
     //리뷰 삭제
-    @DeleteMapping("{reviewId}")
+    @DeleteMapping("/{reviewId}")
     public ResponseEntity<ApiResDto> deleteReview(
             @PathVariable UUID reviewId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         reviewService.deleteReview(reviewId, userDetails);
         return ResponseEntity.ok().body(new ApiResDto("리뷰 삭제 완료", HttpStatus.OK.value()));
+    }
+
+    //관리자 - 삭제된 리뷰 복구
+    @Secured({"ROLE_MANAGER", "ROLE_ADMIN"})
+    @PatchMapping("/admin/restore/{reviewId}")
+    public ApiResDto restoreReview(
+            @PathVariable UUID reviewId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        reviewService.restoreReview(reviewId, userDetails);
+        return new ApiResDto("리뷰 복구 성공", 200);
     }
 }
 

--- a/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/gitandrun/review/controller/ReviewController.java
@@ -89,11 +89,12 @@ public class ReviewController {
             @RequestParam(required = false) Long userId,      // userId로 검색
             @RequestParam(required = false) UUID reviewId,    // reviewId로 검색
             @RequestParam(required = false) UUID storeId,     // storeId로 검색
+            @RequestParam(defaultValue = "false") boolean isDeleted, // 삭제 여부
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "createdAt") String sortBy) {
         Page<AdminReviewResponseDto> reviews = reviewService.searchReviewsWithFilters(
-                keyword, userId, reviewId, storeId, page, size, sortBy);
+                keyword, userId, reviewId, storeId, isDeleted, page, size, sortBy);
         return new ApiResDto("리뷰 조회 성공", 200, reviews);
     }
 

--- a/src/main/java/com/sparta/gitandrun/review/entity/Review.java
+++ b/src/main/java/com/sparta/gitandrun/review/entity/Review.java
@@ -66,4 +66,11 @@ public class Review extends BaseEntity {
         this.setDeletedAt(LocalDateTime.now());
         this.setDeletedBy(user.getUsername());
     }
+
+    public void restoreReview(User user) {
+        this.isDeleted = false;
+        this.setDeletedAt(null);
+        this.setDeletedBy(null);
+        this.setUpdatedBy(user.getUsername());
+    }
 }

--- a/src/main/java/com/sparta/gitandrun/review/entity/Review.java
+++ b/src/main/java/com/sparta/gitandrun/review/entity/Review.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -58,5 +59,11 @@ public class Review extends BaseEntity {
         this.reviewContent = requestDto.getReviewContent();
         this.reviewRating = requestDto.getReviewRating();
         initAuditInfo(user);
+    }
+
+    public void softDelete(User user) {
+        this.isDeleted = true;
+        this.setDeletedAt(LocalDateTime.now());
+        this.setDeletedBy(user.getUsername());
     }
 }

--- a/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/gitandrun/review/repository/ReviewRepository.java
@@ -29,15 +29,17 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
     // 관리자: 모든 리뷰 조회
     @Query("SELECT r FROM Review r " +
-            "WHERE (:keyword IS NULL OR LOWER(r.reviewContent) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+            "WHERE (:keyword IS NULL OR :keyword = '' OR LOWER(r.reviewContent) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
             "AND (:userId IS NULL OR r.user.userId = :userId) " +
             "AND (:reviewId IS NULL OR r.reviewId = :reviewId) " +
-            "AND (:storeId IS NULL OR r.store.storeId = :storeId)")
+            "AND (:storeId IS NULL OR r.store.storeId = :storeId)" +
+            "AND r.isDeleted = :isDeleted")
     Page<Review> searchReviewsWithFilters(
             @Param("keyword") String keyword,
             @Param("userId") Long userId,
             @Param("reviewId") UUID reviewId,
             @Param("storeId") UUID storeId,
+            @Param("isDeleted") boolean isDeleted,
             Pageable pageable);
 
 

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -90,7 +90,7 @@ public class ReviewService {
         return reviews.map(UserReviewResponseDto::new);
     }
 
-    // CUSTOEMR, OWNER - 본인이 작성한 리뷰 조회
+    // CUSTOEMR: 본인이 작성한 리뷰 조회
     @Transactional(readOnly = true)
     public Page<UserReviewResponseDto> getMyReviewsByUserId(Long userId, int page, int size, String sortBy) {
         Pageable pageable = pageable(page, size, sortBy, false);
@@ -152,6 +152,19 @@ public class ReviewService {
         review.softDelete(userDetails.getUser());
     }
 
+    //관리자 - 삭제된 리뷰 복구
+    @Transactional
+    public void restoreReview(UUID reviewId, UserDetailsImpl userDetails) {
+        Review review = getReview(reviewId);
+
+        // 삭제 여부 확인
+        if (!review.isDeleted()) {
+            throw new IllegalArgumentException("삭제되지 않은 리뷰입니다.");
+        }
+
+        review.restoreReview(userDetails.getUser());
+    }
+
     //----------------------------------------------------------------
 
     //리뷰 확인
@@ -163,7 +176,7 @@ public class ReviewService {
     // 리뷰가 비어있는지 확인
     private void reviewEmpty(Page<Review> reviews) {
         if (reviews.isEmpty()) {
-            throw new IllegalArgumentException("리뷰가 존재하지 않습니다.");
+            throw new IllegalArgumentException("리뷰가 없습니다.");
         }
     }
 

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -149,7 +149,7 @@ public class ReviewService {
         Long userId = userDetails.getUser().getUserId();
         Role role = userDetails.getUser().getRole();
         checkPermission(review, userId, role);
-        review.setDeleted(true);
+        review.softDelete(userDetails.getUser());
     }
 
     //----------------------------------------------------------------

--- a/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/gitandrun/review/service/ReviewService.java
@@ -102,7 +102,7 @@ public class ReviewService {
     // 관리자 - 모든 리뷰 검색 (reviewContent, userId, reviewId, storeId)
     @Transactional(readOnly = true)
     public Page<AdminReviewResponseDto> searchReviewsWithFilters(
-            String keyword, Long userId, UUID reviewId, UUID storeId, int page, int size, String sortBy) {
+            String keyword, Long userId, UUID reviewId, UUID storeId, boolean isDeleted, int page, int size, String sortBy) {
         Pageable pageable = pageable(page, size, sortBy, true);
 
         // 필터 조건이 모두 비어 있는지 확인
@@ -117,10 +117,9 @@ public class ReviewService {
             reviewEmpty(allReviews);
             return allReviews.map(AdminReviewResponseDto::new);
         }
-
         // 필터 조건이 있을 경우 필터링해서 조회
         Page<Review> reviews = reviewRepository.searchReviewsWithFilters(
-                keyword, userId, reviewId, storeId, pageable);
+                keyword, userId, reviewId, storeId, isDeleted, pageable);
         reviewEmpty(reviews);
         return reviews.map(AdminReviewResponseDto::new);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #117 

## 📝 Description

- 리뷰 조건 검색 시 삭제 여부 선택 기능을 추가했습니다.
    - Keyword, userId, storeId, reviewId로 리뷰 검색 시 삭제 여부 선택 가능
    - 전체 조회에서는 삭제 여부 상관없이 확인 가능
 - 관리자: 리뷰 복구 기능을 추가했습니다.
    - 삭제 여부 검증 후 복구 기능 추가
    - 복구 시 삭제 상태 false, 삭제일, 삭제자 초기화, 수정자 갱신

## 💬 To Reivewers
