### PR TITLE
DTO에 userId 안 뜨게 수정

### DIFF
--- a/src/main/java/com/sparta/gitandrun/store/dto/LimitedStoreResponse.java
+++ b/src/main/java/com/sparta/gitandrun/store/dto/LimitedStoreResponse.java
@@ -16,7 +16,6 @@ public class LimitedStoreResponse {
     private String address;
     private String addressDetail;
     private String zipCode;
-    private Long userId;
     private Double averageRating;
 
     public LimitedStoreResponse(Store store, Double averageRating) {
@@ -27,7 +26,6 @@ public class LimitedStoreResponse {
         this.address = store.getAddress().getAddress();  // Address 필드 사용
         this.addressDetail = store.getAddress().getAddressDetail();  // Address 필드 사용
         this.zipCode = store.getAddress().getZipCode();  // Address 필드 사용
-        this.userId = store.getUser().getUserId();
         this.averageRating = averageRating != null
                 ? BigDecimal.valueOf(averageRating).setScale(2, RoundingMode.HALF_UP).doubleValue()
                 : null;    }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #124 

## 📝 Description
Customer가 가게를 조회하면 userId가 뜨는데 필요 없다고 생각이 들어 수정하게 되었습니다.

## 💬 To Reivewers
